### PR TITLE
Make Constraint::Length requirement STRONG so that it always gets satisfied

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ We use Github Actions for the CI where we perform the following checks:
 - The code should conform to the default format enforced by `rustfmt`.
 - The code should not contain common style issues `clippy`.
 
-You can also check most of those things yourself locally using `cargo make ci` which will offer you a shorter feedback loop.
+If you install [cargo-make](https://sagiegurari.github.io/cargo-make/), you can also check most of those things yourself locally by running `cargo make ci`, which will offer you a shorter feedback loop.
 
 ## Tests
 


### PR DESCRIPTION
> Upstream: [#527](https://github.com/fdehau/tui-rs/pull/527)

## Description

While trying to create an element one row tall at the bottom of my screen using `Layout`, I noticed that it kept being shrunk to 0. You can observe this behaviour with a program like:

```rust
use tui::layout::{Constraint, Direction, Layout, Rect};

fn main() {
    let area = Rect::new(0, 0, 100, 75);

    let chunks = Layout::default()
        .direction(Direction::Vertical)
        .margin(0)
        .constraints(
            [
                Constraint::Length(1),
                Constraint::Ratio(1, 9),
                Constraint::Ratio(9, 10),
            ]
            .as_ref(),
        )
        .split(area);

    println!("When Length is first, chunks = {:?}", chunks);

    let chunks = Layout::default()
        .direction(Direction::Vertical)
        .margin(0)
        .constraints(
            [
                Constraint::Ratio(1, 10),
                Constraint::Ratio(9, 10),
                Constraint::Length(1),
            ]
            .as_ref(),
        )
        .split(area);

    println!("When Length is last, chunks = {:?}", chunks);
}
```

Before my changes, running this produces:

```
% cargo run -q --example length-last                     
When Length is first, chunks = [Rect { x: 0, y: 0, width: 100, height: 1 }, Rect { x: 0, y: 1, width: 100, height: 8 }, Rect { x: 0, y: 9, width: 100, height: 66 }]
When Length is last, chunks = [Rect { x: 0, y: 0, width: 100, height: 7 }, Rect { x: 0, y: 7, width: 100, height: 67 }, Rect { x: 0, y: 75, width: 100, height: 0 }]
```

This is a result of all of the constraints having `WEAK` strength, and the final `Constraint::Length` getting solved after the `Constraint::Ratio` has already been satisfied to take up the whole screen. You can also see that the heights don't add up to 75 here. This is because `cassowary` is producing fractional values that do sum to 75, but then get truncated when converted from `f64` to `u16`.  

It seems like specifying a precise number of columns or rows via `Length` should take precedence over the more flexible `Ratio`, so I have modiffied the constraint generation to use `STRONG`. I have also changed the constraint for `Ratio` to calculate the goal value using integer arithmetic first and then convert to a float, so that the target value is non-fractional. This seems to be enough to prevent fractional results.

Running the above program now produces:

```
% cargo run -q --example length-last
When Length is first, chunks = [Rect { x: 0, y: 0, width: 100, height: 1 }, Rect { x: 0, y: 1, width: 100, height: 8 }, Rect { x: 0, y: 9, width: 100, height: 66 }]
When Length is last, chunks = [Rect { x: 0, y: 0, width: 100, height: 7 }, Rect { x: 0, y: 7, width: 100, height: 67 }, Rect { x: 0, y: 74, width: 100, height: 1 }]
```

## Testing guidelines

I have added two new tests to `src/layout.rs` that check splitting `Vertical` and `Horizontal` layouts where the `Length` constraint comes last after two `Ratio` constraints. Running `cargo make ci` results in all tests passing.

## Checklist

* [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [X] I have added relevant tests.
* [ ] I have documented all new additions.

Since I haven't added any new APIs, I didn't change any of the docs. (I did update `CONTRIBUTING.md` to link to `cargo-make`, though, to help other future contributors figure out what to do to get it.) Let me know if there's anything you think I should document or otherwise change, and I can do so.
