### PR TITLE
Fix: cassowary/layouts: add extra constraints for fixing Min(v)/Max(v) combination.

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 
-use cassowary::strength::{REQUIRED, WEAK};
+use cassowary::strength::{MEDIUM, REQUIRED, WEAK};
 use cassowary::WeightedRelation::*;
 use cassowary::{Constraint as CassowaryConstraint, Expression, Solver, Variable};
 
@@ -248,17 +248,17 @@ fn split(area: Rect, layout: &Layout) -> Vec<Rect> {
                 ccs.push(elements[i].y | EQ(REQUIRED) | f64::from(dest_area.y));
                 ccs.push(elements[i].height | EQ(REQUIRED) | f64::from(dest_area.height));
                 ccs.push(match *size {
-                    Constraint::Length(v) => elements[i].width | EQ(WEAK) | f64::from(v),
+                    Constraint::Length(v) => elements[i].width | EQ(MEDIUM) | f64::from(v),
                     Constraint::Percentage(v) => {
-                        elements[i].width | EQ(WEAK) | (f64::from(v * dest_area.width) / 100.0)
+                        elements[i].width | EQ(MEDIUM) | (f64::from(v * dest_area.width) / 100.0)
                     }
                     Constraint::Ratio(n, d) => {
                         elements[i].width
-                            | EQ(WEAK)
+                            | EQ(MEDIUM)
                             | (f64::from(dest_area.width) * f64::from(n) / f64::from(d))
                     }
-                    Constraint::Min(v) => elements[i].width | GE(WEAK) | f64::from(v),
-                    Constraint::Max(v) => elements[i].width | LE(WEAK) | f64::from(v),
+                    Constraint::Min(v) => elements[i].width | GE(MEDIUM) | f64::from(v),
+                    Constraint::Max(v) => elements[i].width | LE(MEDIUM) | f64::from(v),
                 });
 
                 match *size {
@@ -280,17 +280,17 @@ fn split(area: Rect, layout: &Layout) -> Vec<Rect> {
                 ccs.push(elements[i].x | EQ(REQUIRED) | f64::from(dest_area.x));
                 ccs.push(elements[i].width | EQ(REQUIRED) | f64::from(dest_area.width));
                 ccs.push(match *size {
-                    Constraint::Length(v) => elements[i].height | EQ(WEAK) | f64::from(v),
+                    Constraint::Length(v) => elements[i].height | EQ(MEDIUM) | f64::from(v),
                     Constraint::Percentage(v) => {
-                        elements[i].height | EQ(WEAK) | (f64::from(v * dest_area.height) / 100.0)
+                        elements[i].height | EQ(MEDIUM) | (f64::from(v * dest_area.height) / 100.0)
                     }
                     Constraint::Ratio(n, d) => {
                         elements[i].height
-                            | EQ(WEAK)
+                            | EQ(MEDIUM)
                             | (f64::from(dest_area.height) * f64::from(n) / f64::from(d))
                     }
-                    Constraint::Min(v) => elements[i].height | GE(WEAK) | f64::from(v),
-                    Constraint::Max(v) => elements[i].height | LE(WEAK) | f64::from(v),
+                    Constraint::Min(v) => elements[i].height | GE(MEDIUM) | f64::from(v),
+                    Constraint::Max(v) => elements[i].height | LE(MEDIUM) | f64::from(v),
                 });
 
                 match *size {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -260,6 +260,16 @@ fn split(area: Rect, layout: &Layout) -> Vec<Rect> {
                     Constraint::Min(v) => elements[i].width | GE(WEAK) | f64::from(v),
                     Constraint::Max(v) => elements[i].width | LE(WEAK) | f64::from(v),
                 });
+
+                match *size {
+                    Constraint::Min(v) => {
+                        ccs.push(elements[i].width | EQ(WEAK) | f64::from(v));
+                    }
+                    Constraint::Max(v) => {
+                        ccs.push(elements[i].width | EQ(WEAK) | f64::from(v));
+                    }
+                    _ => {}
+                }
             }
         }
         Direction::Vertical => {
@@ -282,6 +292,16 @@ fn split(area: Rect, layout: &Layout) -> Vec<Rect> {
                     Constraint::Min(v) => elements[i].height | GE(WEAK) | f64::from(v),
                     Constraint::Max(v) => elements[i].height | LE(WEAK) | f64::from(v),
                 });
+
+                match *size {
+                    Constraint::Min(v) => {
+                        ccs.push(elements[i].height | EQ(WEAK) | f64::from(v));
+                    }
+                    Constraint::Max(v) => {
+                        ccs.push(elements[i].height | EQ(WEAK) | f64::from(v));
+                    }
+                    _ => {}
+                }
             }
         }
     }


### PR DESCRIPTION
> Upstream: [#647](https://github.com/fdehau/tui-rs/pull/647)

## Description
These added weak constraints prevent zero width/height widgets when combining Min(v)/Max(v) together in a chunk.

The UI will now reflow correctly when (re)sizing, gracefully preserving Max(v) constraints as much as possible.

This fixes the root cause of the issues identified in:
https://github.com/fdehau/tui-rs/issues/39
https://github.com/fdehau/tui-rs/issues/420
(amongst probably similar reports).

## Testing guidelines
Combine Min(v) and Max(v) layout constraints in a chunk.

```
...
        let chunks = layout::Layout::default()
            .direction(layout::Direction::Horizontal)
            .constraints([Constraint::Min(50), Constraint::Max(25)])
            .split(frame.size());
...
```
Use any other combination, including Percentage/Ratio/Length with Min/Max.

Resize the window width/height to investigate how the two constraints are now satisfied without 'freaking out' and generating zero-width/height widgets. If all Min(v)/Max(v) constraints cannot be satisfied, they will gracefully degrade.

## Checklist

* [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [x] I have added relevant tests.
* [x] I have documented all new additions.