### PR TITLE
better safe shared layout cache

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -69,8 +69,9 @@ pub struct Layout {
     expand_to_fill: bool,
 }
 
+type Cache = HashMap<(Rect, Layout), Rc<[Rect]>>;
 thread_local! {
-    static LAYOUT_CACHE: RefCell<HashMap<(Rect, Layout), Rc<[Rect]>>> = RefCell::new(HashMap::new());
+    static LAYOUT_CACHE: RefCell<Cache> = RefCell::new(HashMap::new());
 }
 
 impl Default for Layout {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::cmp::{max, min};
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use cassowary::strength::{REQUIRED, WEAK};
 use cassowary::WeightedRelation::*;
@@ -69,7 +70,7 @@ pub struct Layout {
 }
 
 thread_local! {
-    static LAYOUT_CACHE: RefCell<HashMap<(Rect, Layout), Vec<Rect>>> = RefCell::new(HashMap::new());
+    static LAYOUT_CACHE: RefCell<HashMap<(Rect, Layout), Rc<[Rect]>>> = RefCell::new(HashMap::new());
 }
 
 impl Default for Layout {
@@ -183,7 +184,7 @@ impl Layout {
     ///     ]
     /// );
     /// ```
-    pub fn split(&self, area: Rect) -> Vec<Rect> {
+    pub fn split(&self, area: Rect) -> Rc<[Rect]> {
         // TODO: Maybe use a fixed size cache ?
         LAYOUT_CACHE.with(|c| {
             c.borrow_mut()
@@ -194,7 +195,7 @@ impl Layout {
     }
 }
 
-fn split(area: Rect, layout: &Layout) -> Vec<Rect> {
+fn split(area: Rect, layout: &Layout) -> Rc<[Rect]> {
     let mut solver = Solver::new();
     let mut vars: HashMap<Variable, (usize, usize)> = HashMap::new();
     let elements = layout
@@ -202,11 +203,13 @@ fn split(area: Rect, layout: &Layout) -> Vec<Rect> {
         .iter()
         .map(|_| Element::new())
         .collect::<Vec<Element>>();
-    let mut results = layout
+    let mut res = layout
         .constraints
         .iter()
         .map(|_| Rect::default())
-        .collect::<Vec<Rect>>();
+        .collect::<Rc<[Rect]>>();
+
+    let mut results = Rc::get_mut(&mut res).expect("newly created Rc should have no shared refs");
 
     let dest_area = area.inner(&layout.margin);
     for (i, e) in elements.iter().enumerate() {
@@ -323,7 +326,7 @@ fn split(area: Rect, layout: &Layout) -> Vec<Rect> {
             }
         }
     }
-    results
+    res
 }
 
 /// A container used by the solver inside split

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -140,8 +140,8 @@ impl Layout {
     ///         height: 10,
     ///     });
     /// assert_eq!(
-    ///     chunks,
-    ///     vec![
+    ///     chunks[..],
+    ///     [
     ///         Rect {
     ///             x: 2,
     ///             y: 2,
@@ -167,8 +167,8 @@ impl Layout {
     ///         height: 2,
     ///     });
     /// assert_eq!(
-    ///     chunks,
-    ///     vec![
+    ///     chunks[..],
+    ///     [
     ///         Rect {
     ///             x: 0,
     ///             y: 0,

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -280,7 +280,7 @@ impl<'a> Table<'a> {
         if !self.widths.is_empty() {
             constraints.pop();
         }
-        let mut chunks = Layout::default()
+        let chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints(constraints)
             .expand_to_fill(false)
@@ -290,8 +290,9 @@ impl<'a> Table<'a> {
                 width: max_width,
                 height: 1,
             });
+        let mut chunks = &chunks[..];
         if has_selection {
-            chunks.remove(0);
+            chunks = &chunks[1..];
         }
         chunks.iter().step_by(2).map(|c| c.width).collect()
     }


### PR DESCRIPTION
## Description
<!--
A clear and concise description of what this PR changes.
-->

https://github.com/tui-rs-revival/tui-rs-revival/pull/22#issuecomment-1427143924 introduced the idea to return `&'static [Rect]` on `Layout::split` using unsafe, but we can use a safe abstraction here instead with `Rc`.

## Testing guidelines
<!--
A clear and concise description of how the changes can be tested.
For example, you can include a command to run the relevant tests or examples.
You can also include screenshots of the expected behavior.
-->

Using the benchmark introduced in #22, I get these results (master/this respectively)

```
test layout::tests::bench_vertical_split_by_height ... bench: 129 ns/iter (+/- 6)
test layout::tests::bench_vertical_split_by_height ... bench: 100 ns/iter (+/- 3)
```

## Checklist

* [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
* [X] I have added relevant tests.
* [ ] I have documented all new additions.
