### PR TITLE
chore: Integrate `committed` for checking conventional commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,20 @@ jobs:
         run: cargo make ci
         env:
           RUST_BACKTRACE: full
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v3
+      - name: Checkout
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: "Check conventional commits"
+        uses: crate-ci/committed@master
+        with:
+          args: "-vv"
+          commits: "HEAD"

--- a/committed.toml
+++ b/committed.toml
@@ -1,0 +1,16 @@
+# configuration for https://github.com/crate-ci/committed
+
+# https://www.conventionalcommits.org
+style="conventional"
+# disallow merge commits
+merge_commit = false
+# subject is not required to be capitalized
+subject_capitalized = false
+# subject should start with an imperative verb
+imperative_subject = true
+# subject should not end with a punctuation
+subject_not_punctuated = true
+# disable line length
+line_length = 0
+# disable subject length
+subject_length = 0


### PR DESCRIPTION
See: https://github.com/crate-ci/committed
Configuration options: https://github.com/crate-ci/committed/blob/master/docs/reference.md
Closes #50 