### PR TITLE
fix(ci): Bump Rust version to 1.63.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: ["1.59.0", "stable"]
+        rust: ["1.60.0", "stable"]
         include:
           - os: ubuntu-latest
             cargo_make_path: ~/.cargo/bin/cargo-make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: ["1.60.0", "stable"]
+        rust: ["1.63.0", "stable"]
         include:
           - os: ubuntu-latest
             cargo_make_path: ~/.cargo/bin/cargo-make


### PR DESCRIPTION
This PR fixes the following build error:

```
error: failed to compile `cargo-make v0.35.16`, intermediate artifacts can be found at `/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/cargo-installa5ntdq`

Caused by:
  package `base64ct v1.6.0` cannot be built because it requires rustc 1.60 or newer, while the currently active rustc version is 1.59.0
```
