### PR TITLE
docs: update to build more backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ rust-version = "1.59.0"
 [features]
 default = ["crossterm"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 bitflags = "1.3"
 cassowary = "0.3"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -176,7 +176,7 @@ impl Buffer {
         &mut self.content[i]
     }
 
-    /// Returns the index in the Vec<Cell> for the given global (x, y) coordinates.
+    /// Returns the index in the `Vec<Cell>` for the given global (x, y) coordinates.
     ///
     /// Global coordinates are offset by the Buffer's area offset (`x`/`y`).
     ///


### PR DESCRIPTION
Enable more backends to be built into the default docs than just termion. These were the only backends that built in a representative environment of docs.rs. Options come from https://docs.rs/about#metadata