### PR TITLE
fix(ci): Test MSRV compatibility on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: ["1.63.0", "stable"]
+        rust: ["1.59.0", "stable"]
         include:
           - os: ubuntu-latest
             triple: x86_64-unknown-linux-musl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
         rust: ["1.63.0", "stable"]
         include:
           - os: ubuntu-latest
-            cargo_make_path: ~/.cargo/bin/cargo-make
+            triple: x86_64-unknown-linux-musl
           - os: windows-latest
-            cargo_make_path: ~\.cargo\bin\cargo-make.exe
+            triple: x86_64-pc-windows-msvc
           - os: macos-latest
-            cargo_make_path: ~/.cargo/bin/cargo-make
+            triple: x86_64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: hecrj/setup-rust-action@50a120e4d34903c2c1383dec0e9b1d349a9cc2b1
@@ -31,15 +31,26 @@ jobs:
           rust-version: ${{ matrix.rust }}
           components: rustfmt,clippy
       - uses: actions/checkout@v3
-      - name: "Cache cargo make"
-        id: cache-cargo-make
-        uses: actions/cache@v3
-        with:
-          path: ${{ matrix.cargo_make_path }}
-          key: ${{ runner.os }}-${{ matrix.rust }}-cargo-make-${{ env.CI_CARGO_MAKE_VERSION }}
-      - name: "Install cargo-make"
-        if: steps.cache-cargo-make.outputs.cache-hit != 'true'
-        run: cargo install cargo-make --version ${{ env.CI_CARGO_MAKE_VERSION }}
+      - name: Install cargo-make on Linux or macOS
+        if: ${{ runner.os != 'windows' }}
+        shell: bash
+        run: |
+          curl -LO 'https://github.com/sagiegurari/cargo-make/releases/download/${{ env.CI_CARGO_MAKE_VERSION }}/cargo-make-v${{ env.CI_CARGO_MAKE_VERSION }}-${{ matrix.triple }}.zip'
+          unzip 'cargo-make-v${{ env.CI_CARGO_MAKE_VERSION }}-${{ matrix.triple }}.zip'
+          cp 'cargo-make-v${{ env.CI_CARGO_MAKE_VERSION }}-${{ matrix.triple }}/cargo-make' ~/.cargo/bin/
+          cargo make --version
+      - name: Install cargo-make on Windows
+        if: ${{ runner.os == 'windows' }}
+        shell: bash
+        run: |
+          # `cargo-make-v0.35.16-{target}/` directory is created on Linux and macOS, but it is not creatd on Windows.
+          mkdir cargo-make-temporary
+          cd cargo-make-temporary
+          curl -LO 'https://github.com/sagiegurari/cargo-make/releases/download/${{ env.CI_CARGO_MAKE_VERSION }}/cargo-make-v${{ env.CI_CARGO_MAKE_VERSION }}-${{ matrix.triple }}.zip'
+          unzip 'cargo-make-v${{ env.CI_CARGO_MAKE_VERSION }}-${{ matrix.triple }}.zip'
+          cp cargo-make.exe ~/.cargo/bin/
+          cd ..
+          cargo make --version
       - name: "Format / Build / Test"
         run: cargo make ci
         env:


### PR DESCRIPTION
Fixes #84

This PR offers two changes:

- 6d7de6e: Install official pre-built `cargo-make` binary instead of building it from source. This change also has the benefit that we no longer need to take care about cache state of built `cargo-make` binary.
- 3474078: Change Rust version tested on CI from 1.63.0 to 1.59.0

I tested these changes on my forked repository and confirmed all jobs passed: https://github.com/rhysd/tui-rs-revival/actions/runs/4360282621/jobs/7623022109