### PR TITLE
Fix tests for title_on_bottom

### DIFF
--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -384,7 +384,7 @@ fn widgets_block_title_alignment_bottom() {
     test_case(
         Alignment::Left,
         Borders::LEFT | Borders::TOP | Borders::RIGHT,
-        Buffer::with_lines(vec![" ┌───────────┐ ", " └Title──────┘ "]),
+        Buffer::with_lines(vec![" ┌───────────┐ ", " │Title      │ "]),
     );
 
     // title bottom-left with no left border
@@ -419,7 +419,7 @@ fn widgets_block_title_alignment_bottom() {
     test_case(
         Alignment::Center,
         Borders::LEFT | Borders::TOP | Borders::RIGHT,
-        Buffer::with_lines(vec![" ┌───────────┐ ", " └   Title   ┘ "]),
+        Buffer::with_lines(vec![" ┌───────────┐ ", " │   Title   │ "]),
     );
 
     // title center with no left border
@@ -454,7 +454,7 @@ fn widgets_block_title_alignment_bottom() {
     test_case(
         Alignment::Right,
         Borders::LEFT | Borders::TOP | Borders::RIGHT,
-        Buffer::with_lines(vec![" ┌───────────┐ ", " └      Title┘ "]),
+        Buffer::with_lines(vec![" ┌───────────┐ ", " │      Title│ "]),
     );
 
     // title bottom-right with no left border


### PR DESCRIPTION
Fix tests for title_on_bottom, previously these had incorrect expected values that didn't line up with expected behaviour or the tests from widgets_block_title_alignment.