### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Features
 
-* Add option to `widgets::List` to repeat the hightlight symbol for each line of multi-line items (#533).
+* Add option to `widgets::List` to repeat the highlight symbol for each line of multi-line items (#533).
 * Add option to control the alignment of `Axis` labels in the `Chart` widget (#568).
 
 ### Breaking changes
@@ -276,7 +276,7 @@ In this new release, you may now write this as:
 ```rust
 Block::default()
     .style(Style::default().bg(Color::Green))
-    // The style is not overidden anymore, we simply add new style rule for the title.
+    // The style is not overridden anymore, we simply add new style rule for the title.
     .title(Span::styled("My title", Style::default().add_modifier(Modifier::BOLD)))
 ```
 
@@ -284,9 +284,9 @@ In addition, the crate now provides a method `patch` to combine two styles into 
 rules:
 
 ```rust
-let style = Style::default().modifer(Modifier::BOLD);
+let style = Style::default().modifier(Modifier::BOLD);
 let style = style.patch(Style::default().add_modifier(Modifier::ITALIC));
-// style.modifer == Modifier::BOLD | Modifier::ITALIC, the modifier has been enriched not overidden
+// style.modifier == Modifier::BOLD | Modifier::ITALIC, the modifier has been enriched not overridden
 ```
 
 - `Style::modifier` has been removed in favor of `Style::add_modifier` and `Style::remove_modifier`.
@@ -604,7 +604,7 @@ let style = Style::default().add_modifier(Modifier::ITALIC | Modifier::BOLD);
 
 ### Bug Fixes
 
-* Ensure correct behavoir of the alternate screens with the `Crossterm` backend.
+* Ensure correct behavior of the alternate screens with the `Crossterm` backend.
 * Fix out of bounds panic when two `Buffer` are merged.
 
 ## v0.4.0 - 2019-02-03
@@ -673,7 +673,7 @@ additional `termion` features.
 
 * Replace `Item` by a generic and flexible `Text` that can be used in both
 `Paragraph` and `List` widgets.
-* Remove unecessary borrows on `Style`.
+* Remove unnecessary borrows on `Style`.
 
 ## v0.3.0-beta.0 - 2018-09-04
 
@@ -696,7 +696,7 @@ widgets on the given `Frame`
 * All widgets use the consumable builder pattern
 * `SelectableList` can have no selected item and the highlight symbol is hidden
 in this case
-* Remove markup langage inside `Paragraph`. `Paragraph` now expects an iterator
+* Remove markup language inside `Paragraph`. `Paragraph` now expects an iterator
 of `Text` items
 
 ## v0.2.3 - 2018-06-09
@@ -704,7 +704,7 @@ of `Text` items
 ### Features
 
 * Add `start_corner` option for `List`
-* Add more text aligment options for `Paragraph`
+* Add more text alignment options for `Paragraph`
 
 ## v0.2.2 - 2018-05-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ You can then resume the conversation by replying to this new issue you have crea
 
 ### Closing Issues
 
-If you close an issue that you have "imported" to this fork, please make sure that you add the issue to the **CLOSED_ISSUES.md**. This will enable us to keep track of which issues have been closed from the original repo, in case we are able to have the original repository transfered.
+If you close an issue that you have "imported" to this fork, please make sure that you add the issue to the **CLOSED_ISSUES.md**. This will enable us to keep track of which issues have been closed from the original repo, in case we are able to have the original repository transferred.
 
 # Contributing
 

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -461,7 +461,7 @@ where
         painter(&mut ctx);
         ctx.finish();
 
-        // Retreive painted points for each layer
+        // Retrieve painted points for each layer
         for layer in ctx.layers {
             for (i, (ch, color)) in layer
                 .string

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -231,7 +231,7 @@ impl<'a> StatefulWidget for List<'a> {
 
             let is_selected = state.selected.map(|s| s == i).unwrap_or(false);
             for (j, line) in item.content.lines.iter().enumerate() {
-                // if the item is selected, we need to display the hightlight symbol:
+                // if the item is selected, we need to display the highlight symbol:
                 // - either for the first line of the item only,
                 // - or for each line of the item if the appropriate option is set
                 let symbol = if is_selected && (j == 0 || self.repeat_highlight_symbol) {

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -127,7 +127,7 @@ pub struct LineTruncator<'a, 'b> {
     symbols: &'b mut dyn Iterator<Item = StyledGrapheme<'a>>,
     max_line_width: u16,
     current_line: Vec<StyledGrapheme<'a>>,
-    /// Record the offet to skip render
+    /// Record the offset to skip render
     horizontal_offset: u16,
 }
 
@@ -438,7 +438,7 @@ mod test {
         assert_eq!(line_truncator, vec!["                    "]);
     }
 
-    /// Tests an input starting with a letter, folowed by spaces - some of the behaviour is
+    /// Tests an input starting with a letter, followed by spaces - some of the behaviour is
     /// incidental.
     #[test]
     fn line_composer_char_plus_lots_of_spaces() {

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -65,7 +65,7 @@ where
 /// Row::new(vec!["Cell1", "Cell2", "Cell3"]);
 /// ```
 ///
-/// But if you need a bit more control over individual cells, you can explicity create [`Cell`]s:
+/// But if you need a bit more control over individual cells, you can explicitly create [`Cell`]s:
 /// ```rust
 /// # use tui::widgets::{Row, Cell};
 /// # use tui::style::{Style, Color};
@@ -116,7 +116,7 @@ impl<'a> Row<'a> {
         self
     }
 
-    /// Set the [`Style`] of the entire row. This [`Style`] can be overriden by the [`Style`] of a
+    /// Set the [`Style`] of the entire row. This [`Style`] can be overridden by the [`Style`] of a
     /// any individual [`Cell`] or event by their [`Text`] content.
     pub fn style(mut self, style: Style) -> Self {
         self.style = style;

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -20,15 +20,15 @@ fn terminal_draw_returns_the_completed_frame() -> Result<(), Box<dyn Error>> {
     let backend = TestBackend::new(10, 10);
     let mut terminal = Terminal::new(backend)?;
     let frame = terminal.draw(|f| {
-        let paragrah = Paragraph::new("Test");
-        f.render_widget(paragrah, f.size());
+        let paragraph = Paragraph::new("Test");
+        f.render_widget(paragraph, f.size());
     })?;
     assert_eq!(frame.buffer.get(0, 0).symbol, "T");
     assert_eq!(frame.area, Rect::new(0, 0, 10, 10));
     terminal.backend_mut().resize(8, 8);
     let frame = terminal.draw(|f| {
-        let paragrah = Paragraph::new("test");
-        f.render_widget(paragrah, f.size());
+        let paragraph = Paragraph::new("test");
+        f.render_widget(paragraph, f.size());
     })?;
     assert_eq!(frame.buffer.get(0, 0).symbol, "t");
     assert_eq!(frame.area, Rect::new(0, 0, 8, 8));

--- a/tests/widgets_chart.rs
+++ b/tests/widgets_chart.rs
@@ -469,7 +469,7 @@ fn widgets_chart_can_have_a_legend() {
         "└──────────────────────────────────────────────────────────┘",
     ]);
 
-    // Set expected backgound color
+    // Set expected background color
     for row in 0..30 {
         for col in 0..60 {
             expected.get_mut(col, row).set_bg(Color::White);


### PR DESCRIPTION
Found via `typos --format brief`