### PR TITLE
docs: fixup remaining tui references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 ---
 
 <!--
-Hi there, sorry `tui` is not working as expected.
+Hi there, sorry `ratatui` is not working as expected.
 Please fill this bug report conscientiously.
 A detailed and complete issue is more likely to be processed quickly.
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ The only exception to this rule is if it's to fix **reproducible slowness.**
 
 [cargo-make]: https://github.com/sagiegurari/cargo-make "cargo-make"
 
-`tui` is an ordinary Rust project where common tasks are managed with [cargo-make].
+`ratatui` is an ordinary Rust project where common tasks are managed with [cargo-make].
 It wraps common `cargo` commands with sane defaults depending on your platform of choice.
 Building the project should be as easy as running `cargo make build`.
 
@@ -56,6 +56,6 @@ You can also check most of those things yourself locally using `cargo make ci` w
 ## Tests
 
 The test coverage of the crate is far from being ideal but we already have a fair amount of tests in place.
-Beside the usual doc and unit tests, one of the most valuable test you can write for `tui` is a test again the `TestBackend`.
+Beside the usual doc and unit tests, one of the most valuable test you can write for `ratatui` is a test against the `TestBackend`.
 It allows you to assert the content of the output buffer that would have been flushed to the terminal after a given draw call.
 See `widgets_block_renders` in [tests/widgets_block.rs](./tests/widget_block.rs) for an example.

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -127,7 +127,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
         Spans::from("with the `reset` command"),
         Spans::from(""),
         Spans::from("with the chained panic hook enabled,"),
-        Spans::from("you should see the panic report as you would without tui"),
+        Spans::from("you should see the panic report as you would without ratatui"),
         Spans::from(""),
         Spans::from("try first without the panic handler to see the difference"),
     ];

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -168,7 +168,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
             {}
 
         InputMode::Editing => {
-            // Make the cursor visible and ask tui-rs to put it at the specified coordinates after rendering
+            // Make the cursor visible and ask ratatui to put it at the specified coordinates after rendering
             f.set_cursor(
                 // Put cursor past the end of the input text
                 chunks[1].x + app.input.width() as u16 + 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,17 @@
-//! [tui](https://github.com/fdehau/tui-rs) is a library used to build rich
+//! [ratatui](https://github.com/tui-rs-revival/ratatui) is a library used to build rich
 //! terminal users interfaces and dashboards.
 //!
-//! ![](https://raw.githubusercontent.com/fdehau/tui-rs/master/assets/demo.gif)
+//! ![](https://raw.githubusercontent.com/tui-rs-revival/ratatui/master/assets/demo.gif)
 //!
 //! # Get started
 //!
-//! ## Adding `tui` as a dependency
+//! ## Adding `ratatui` as a dependency
 //!
+//! Add the following to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! tui = "0.19"
-//! crossterm = "0.25"
+//! crossterm = "0.26"
+//! ratatui = "0.20"
 //! ```
 //!
 //! The crate is using the `crossterm` backend by default that works on most platforms. But if for
@@ -20,7 +21,7 @@
 //! ```toml
 //! [dependencies]
 //! termion = "1.5"
-//! tui = { version = "0.19", default-features = false, features = ['termion'] }
+//! ratatui = { version = "0.20", default-features = false, features = ['termion'] }
 //!
 //! ```
 //!
@@ -28,7 +29,7 @@
 //!
 //! ## Creating a `Terminal`
 //!
-//! Every application using `tui` should start by instantiating a `Terminal`. It is a light
+//! Every application using `ratatui` should start by instantiating a `Terminal`. It is a light
 //! abstraction over available backends that provides basic functionalities such as clearing the
 //! screen, hiding the cursor, etc.
 //!

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,7 +1,7 @@
 //! Primitives for styled text.
 //!
 //! A terminal UI is at its root a lot of strings. In order to make it accessible and stylish,
-//! those strings may be associated to a set of styles. `tui` has three ways to represent them:
+//! those strings may be associated to a set of styles. `ratatui` has three ways to represent them:
 //! - A single line string where all graphemes have the same style is represented by a [`Span`].
 //! - A single line string where each grapheme may have its own style is represented by [`Spans`].
 //! - A multiple line string where each grapheme may have its own style is represented by a
@@ -11,7 +11,7 @@
 //! is a [`Spans`].
 //!
 //! Keep it mind that a lot of widgets will use those types to advertise what kind of string is
-//! supported for their properties. Moreover, `tui` provides convenient `From` implementations so
+//! supported for their properties. Moreover, `ratatui` provides convenient `From` implementations so
 //! that you can start by using simple `String` or `&str` and then promote them to the previous
 //! primitives when you need additional styling capabilities.
 //!

--- a/src/widgets/clear.rs
+++ b/src/widgets/clear.rs
@@ -2,7 +2,7 @@ use crate::{buffer::Buffer, layout::Rect, widgets::Widget};
 
 /// A widget to clear/reset a certain area to allow overdrawing (e.g. for popups).
 ///
-/// This widget **cannot be used to clear the terminal on the first render** as `tui` assumes the
+/// This widget **cannot be used to clear the terminal on the first render** as `ratatui` assumes the
 /// render area is empty. Use [`crate::Terminal::clear`] instead.
 ///
 /// # Examples

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -165,7 +165,7 @@ pub trait Widget {
 /// loop {
 ///     terminal.draw(|f| {
 ///         // The items managed by the application are transformed to something
-///         // that is understood by tui.
+///         // that is understood by ratatui.
 ///         let items: Vec<ListItem>= events.items.iter().map(|i| ListItem::new(i.as_ref())).collect();
 ///         // The `List` widget is then built with those items.
 ///         let list = List::new(items);


### PR DESCRIPTION
There were a few remaining references in the code docs etc. to tui rather than ratatui. This fixes those references.

E.g. see https://docs.rs/ratatui/0.20.0/ratatui/index.html