### PR TITLE
fix(canvas)!: use full block for Marker::Block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1", optional = true, features = ["derive"]}
 [dev-dependencies]
 rand = "0.8"
 argh = "0.1"
+indoc = "2.0"
 
 [[example]]
 name = "barchart"

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -7,6 +7,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
+    symbols::Marker,
     text::Span,
     widgets::{
         canvas::{Canvas, Map, MapResolution, Rectangle},
@@ -29,6 +30,8 @@ struct App {
     vy: f64,
     dir_x: bool,
     dir_y: bool,
+    tick_count: u64,
+    marker: Marker,
 }
 
 impl App {
@@ -48,10 +51,22 @@ impl App {
             vy: 1.0,
             dir_x: true,
             dir_y: true,
+            tick_count: 0,
+            marker: Marker::Dot,
         }
     }
 
     fn on_tick(&mut self) {
+        self.tick_count += 1;
+        // only change marker every 4 ticks (1s) to avoid stroboscopic effect
+        if (self.tick_count % 4) == 0 {
+            self.marker = match self.marker {
+                Marker::Dot => Marker::Block,
+                Marker::Block => Marker::Bar,
+                Marker::Bar => Marker::Braille,
+                Marker::Braille => Marker::Dot,
+            };
+        }
         if self.ball.x < self.playground.left() as f64
             || self.ball.x + self.ball.width > self.playground.right() as f64
         {
@@ -155,6 +170,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
         .split(f.size());
     let canvas = Canvas::default()
         .block(Block::default().borders(Borders::ALL).title("World"))
+        .marker(app.marker)
         .paint(|ctx| {
             ctx.draw(&Map {
                 color: Color::White,
@@ -171,6 +187,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
     f.render_widget(canvas, chunks[0]);
     let canvas = Canvas::default()
         .block(Block::default().borders(Borders::ALL).title("Pong"))
+        .marker(app.marker)
         .paint(|ctx| {
             ctx.draw(&app.ball);
         })

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -228,6 +228,8 @@ pub enum Marker {
     Dot,
     /// One point per cell in shape of a block
     Block,
+    /// One point per cell in the shape of a bar
+    Bar,
     /// Up to 8 points per cell
     Braille,
 }


### PR DESCRIPTION
Fixes https://github.com/tui-rs-revival/ratatui/issues/82

When drawing a vertical line on a canvas, using `Marker::Block` would
draw a gap in between each line. This is because the default block
character was a half bar. This changes the default block character to a
full block, and adds a new marker type `Marker::Bar` to replace the
current `Marker::Block`.

BREAKING CHANGE: `Marker::Block` now uses a full block character, and
`Marker::Bar` is the new half block character.

- Adds tests for each `Marker` in the canvas widget.
- Adds marker to the canvas example to show the difference between
  the marker types.
