### PR TITLE
feat(calendar): add calendar widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.59.0"
 
 [features]
 default = ["crossterm"]
+widget-calendar = ["time"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -31,6 +32,7 @@ unicode-width = "0.1"
 termion = { version = "2.0", optional = true }
 crossterm = { version = "0.26", optional = true }
 serde = { version = "1", optional = true, features = ["derive"]}
+time = { version = "0.3.11", optional = true, features = ["local-offset"]}
 
 [dev-dependencies]
 rand = "0.8"
@@ -48,6 +50,10 @@ required-features = ["crossterm"]
 [[example]]
 name = "canvas"
 required-features = ["crossterm"]
+
+[[example]]
+name = "calendar"
+required-features = ["crossterm", "widget-calendar"]
 
 [[example]]
 name = "chart"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.59.0"
 
 [features]
 default = ["crossterm"]
+all-widgets = ["widget-calendar"]
 widget-calendar = ["time"]
 
 [package.metadata.docs.rs]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -100,11 +100,11 @@ args = [
 ]
 
 [tasks.test-crossterm]
-env = { TUI_FEATURES = "serde,crossterm" }
+env = { TUI_FEATURES = "serde,crossterm,all-widgets" }
 run_task = "test"
 
 [tasks.test-termion]
-env = { TUI_FEATURES = "serde,termion" }
+env = { TUI_FEATURES = "serde,termion,all-widgets" }
 run_task = "test"
 
 [tasks.test]

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -1,0 +1,286 @@
+use std::{error::Error, io, rc::Rc};
+
+use crossterm::{
+    event::{self, Event, KeyCode},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    Frame, Terminal,
+};
+
+use time::{Date, Month, OffsetDateTime};
+
+use ratatui::widgets::calendar::{CalendarEventStore, DateStyler, Monthly};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    loop {
+        let _ = terminal.draw(|f| draw(f));
+
+        if let Event::Key(key) = event::read()? {
+            #[allow(clippy::single_match)]
+            match key.code {
+                KeyCode::Char(_) => {
+                    break;
+                }
+                _ => {}
+            };
+        }
+    }
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+fn draw<B: Backend>(f: &mut Frame<B>) {
+    let app_area = f.size();
+
+    let calarea = Rect {
+        x: app_area.x + 1,
+        y: app_area.y + 1,
+        height: app_area.height - 1,
+        width: app_area.width - 1,
+    };
+
+    let mut start = OffsetDateTime::now_local()
+        .unwrap()
+        .date()
+        .replace_month(Month::January)
+        .unwrap()
+        .replace_day(1)
+        .unwrap();
+
+    let list = make_dates(start.year());
+
+    for chunk in split_rows(&calarea)
+        .iter()
+        .flat_map(|row| split_cols(row).to_vec())
+    {
+        let cal = cals::get_cal(start.month(), start.year(), &list);
+        f.render_widget(cal, chunk);
+        start = start.replace_month(start.month().next()).unwrap();
+    }
+}
+
+fn split_rows(area: &Rect) -> Rc<[Rect]> {
+    let list_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(0)
+        .constraints(
+            [
+                Constraint::Percentage(33),
+                Constraint::Percentage(33),
+                Constraint::Percentage(33),
+            ]
+            .as_ref(),
+        );
+
+    list_layout.split(*area)
+}
+
+fn split_cols(area: &Rect) -> Rc<[Rect]> {
+    let list_layout = Layout::default()
+        .direction(Direction::Horizontal)
+        .margin(0)
+        .constraints(
+            [
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+            ]
+            .as_ref(),
+        );
+
+    list_layout.split(*area)
+}
+
+fn make_dates(current_year: i32) -> CalendarEventStore {
+    let mut list = CalendarEventStore::today(
+        Style::default()
+            .add_modifier(Modifier::BOLD)
+            .bg(Color::Blue),
+    );
+
+    // Holidays
+    let holiday_style = Style::default()
+        .fg(Color::Red)
+        .add_modifier(Modifier::UNDERLINED);
+
+    // new year's
+    list.add(
+        Date::from_calendar_date(current_year, Month::January, 1).unwrap(),
+        holiday_style,
+    );
+    // next new_year's for December "show surrounding"
+    list.add(
+        Date::from_calendar_date(current_year + 1, Month::January, 1).unwrap(),
+        holiday_style,
+    );
+    // groundhog day
+    list.add(
+        Date::from_calendar_date(current_year, Month::February, 2).unwrap(),
+        holiday_style,
+    );
+    // april fool's
+    list.add(
+        Date::from_calendar_date(current_year, Month::April, 1).unwrap(),
+        holiday_style,
+    );
+    // earth day
+    list.add(
+        Date::from_calendar_date(current_year, Month::April, 22).unwrap(),
+        holiday_style,
+    );
+    // star wars day
+    list.add(
+        Date::from_calendar_date(current_year, Month::May, 4).unwrap(),
+        holiday_style,
+    );
+    // festivus
+    list.add(
+        Date::from_calendar_date(current_year, Month::December, 23).unwrap(),
+        holiday_style,
+    );
+    // new year's eve
+    list.add(
+        Date::from_calendar_date(current_year, Month::December, 31).unwrap(),
+        holiday_style,
+    );
+
+    // seasons
+    let season_style = Style::default()
+        .fg(Color::White)
+        .bg(Color::Yellow)
+        .add_modifier(Modifier::UNDERLINED);
+    // spring equinox
+    list.add(
+        Date::from_calendar_date(current_year, Month::March, 22).unwrap(),
+        season_style,
+    );
+    // summer solstice
+    list.add(
+        Date::from_calendar_date(current_year, Month::June, 21).unwrap(),
+        season_style,
+    );
+    // fall equinox
+    list.add(
+        Date::from_calendar_date(current_year, Month::September, 22).unwrap(),
+        season_style,
+    );
+    list.add(
+        Date::from_calendar_date(current_year, Month::December, 21).unwrap(),
+        season_style,
+    );
+    list
+}
+
+mod cals {
+    use super::*;
+
+    pub(super) fn get_cal<'a, S: DateStyler>(m: Month, y: i32, es: S) -> Monthly<'a, S> {
+        use Month::*;
+        match m {
+            May => example1(m, y, es),
+            June => example2(m, y, es),
+            July => example3(m, y, es),
+            December => example3(m, y, es),
+            February => example4(m, y, es),
+            November => example5(m, y, es),
+            _ => default(m, y, es),
+        }
+    }
+
+    fn default<'a, S: DateStyler>(m: Month, y: i32, es: S) -> Monthly<'a, S> {
+        let default_style = Style::default()
+            .add_modifier(Modifier::BOLD)
+            .bg(Color::Rgb(50, 50, 50));
+
+        Monthly::new(Date::from_calendar_date(y, m, 1).unwrap(), es)
+            .show_month_header(Style::default())
+            .default_style(default_style)
+    }
+
+    fn example1<'a, S: DateStyler>(m: Month, y: i32, es: S) -> Monthly<'a, S> {
+        let default_style = Style::default()
+            .add_modifier(Modifier::BOLD)
+            .bg(Color::Rgb(50, 50, 50));
+
+        Monthly::new(Date::from_calendar_date(y, m, 1).unwrap(), es)
+            .show_surrounding(default_style)
+            .default_style(default_style)
+            .show_month_header(Style::default())
+    }
+
+    fn example2<'a, S: DateStyler>(m: Month, y: i32, es: S) -> Monthly<'a, S> {
+        let header_style = Style::default()
+            .add_modifier(Modifier::BOLD)
+            .add_modifier(Modifier::DIM)
+            .fg(Color::LightYellow);
+
+        let default_style = Style::default()
+            .add_modifier(Modifier::BOLD)
+            .bg(Color::Rgb(50, 50, 50));
+
+        Monthly::new(Date::from_calendar_date(y, m, 1).unwrap(), es)
+            .show_weekdays_header(header_style)
+            .default_style(default_style)
+            .show_month_header(Style::default())
+    }
+
+    fn example3<'a, S: DateStyler>(m: Month, y: i32, es: S) -> Monthly<'a, S> {
+        let header_style = Style::default()
+            .add_modifier(Modifier::BOLD)
+            .fg(Color::Green);
+
+        let default_style = Style::default()
+            .add_modifier(Modifier::BOLD)
+            .bg(Color::Rgb(50, 50, 50));
+
+        Monthly::new(Date::from_calendar_date(y, m, 1).unwrap(), es)
+            .show_surrounding(Style::default().add_modifier(Modifier::DIM))
+            .show_weekdays_header(header_style)
+            .default_style(default_style)
+            .show_month_header(Style::default())
+    }
+
+    fn example4<'a, S: DateStyler>(m: Month, y: i32, es: S) -> Monthly<'a, S> {
+        let header_style = Style::default()
+            .add_modifier(Modifier::BOLD)
+            .fg(Color::Green);
+
+        let default_style = Style::default()
+            .add_modifier(Modifier::BOLD)
+            .bg(Color::Rgb(50, 50, 50));
+
+        Monthly::new(Date::from_calendar_date(y, m, 1).unwrap(), es)
+            .show_weekdays_header(header_style)
+            .default_style(default_style)
+    }
+
+    fn example5<'a, S: DateStyler>(m: Month, y: i32, es: S) -> Monthly<'a, S> {
+        let header_style = Style::default()
+            .add_modifier(Modifier::BOLD)
+            .fg(Color::Green);
+
+        let default_style = Style::default()
+            .add_modifier(Modifier::BOLD)
+            .bg(Color::Rgb(50, 50, 50));
+
+        Monthly::new(Date::from_calendar_date(y, m, 1).unwrap(), es)
+            .show_month_header(header_style)
+            .default_style(default_style)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,14 @@
 //!
 //! The same logic applies for all other available backends.
 //!
+//! ### Features
+//!
+//! Widgets which add dependencies are gated behind feature flags to prevent unused transitive
+//! dependencies. The available features are:
+//!
+//! * `widget-calendar` - enables [`widgets::calendar`] and adds a dependency on the [time
+//! crate](https://crates.io/crates/time).
+//!
 //! ## Creating a `Terminal`
 //!
 //! Every application using `ratatui` should start by instantiating a `Terminal`. It is a light

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -211,3 +211,35 @@ impl Default for CalendarEventStore {
         Self(HashMap::with_capacity(4))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::style::Color;
+    use time::Month;
+
+    #[test]
+    fn event_store() {
+        let a = (
+            Date::from_calendar_date(2023, Month::January, 1).unwrap(),
+            Style::default(),
+        );
+        let b = (
+            Date::from_calendar_date(2023, Month::January, 2).unwrap(),
+            Style::default().bg(Color::Red).fg(Color::Blue),
+        );
+        let mut s = CalendarEventStore::default();
+        s.add(b.0, b.1);
+
+        assert_eq!(
+            s.get_style(a.0),
+            a.1,
+            "Date not added to the styler should look up as Style::default()"
+        );
+        assert_eq!(
+            s.get_style(b.0),
+            b.1,
+            "Date added to styler should return the provided style"
+        );
+    }
+}

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -1,0 +1,213 @@
+//! A simple calendar widget. `(feature: widget-calendar)`
+//!
+//!
+//!
+//! The [`Monthly`] widget will display a calendar for the monh provided in `display_date`. Days are
+//! styled using the default style unless:
+//! * `show_surrounding` is set, then days not in the `display_date` month will use that style.
+//! * a style is returned by the [`DateStyler`] for the day
+//!
+//! [`Monthly`] has several controls for what should be displayed
+use std::collections::HashMap;
+
+use crate::{
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+    text::{Span, Spans},
+    widgets::{Block, Widget},
+};
+
+use time::{Date, Duration, OffsetDateTime};
+
+/// Display a month calendar for the month containing `display_date`
+pub struct Monthly<'a, S: DateStyler> {
+    display_date: Date,
+    events: S,
+    show_surrounding: Option<Style>,
+    show_weekday: Option<Style>,
+    show_month: Option<Style>,
+    default_style: Style,
+    block: Option<Block<'a>>,
+}
+
+impl<'a, S: DateStyler> Monthly<'a, S> {
+    /// Construct a calendar for the `display_date` and highlight the `events`
+    pub fn new(display_date: Date, events: S) -> Self {
+        Self {
+            display_date,
+            events,
+            show_surrounding: None,
+            show_weekday: None,
+            show_month: None,
+            default_style: Style::default(),
+            block: None,
+        }
+    }
+
+    /// Fill the calendar slots for days not in the current month also, this causes each line to be
+    /// completely filled. If there is an event style for a date, this style will be patched with
+    /// the event's style
+    pub fn show_surrounding(mut self, style: Style) -> Self {
+        self.show_surrounding = Some(style);
+        self
+    }
+
+    /// Display a header containing weekday abbreviations
+    pub fn show_weekdays_header(mut self, style: Style) -> Self {
+        self.show_weekday = Some(style);
+        self
+    }
+
+    /// Display a header containing the month and year
+    pub fn show_month_header(mut self, style: Style) -> Self {
+        self.show_month = Some(style);
+        self
+    }
+
+    /// How to render otherwise unstyled dates
+    pub fn default_style(mut self, s: Style) -> Self {
+        self.default_style = s;
+        self
+    }
+
+    /// Render the calendar within a [Block](ratatui::widgets::Block)
+    pub fn block(mut self, b: Block<'a>) -> Self {
+        self.block = Some(b);
+        self
+    }
+
+    /// Return a style with only the background from the default style
+    fn default_bg(&self) -> Style {
+        match self.default_style.bg {
+            None => Style::default(),
+            Some(c) => Style::default().bg(c),
+        }
+    }
+
+    /// All logic to style a date goes here.
+    fn format_date(&self, date: Date) -> Span {
+        if date.month() != self.display_date.month() {
+            match self.show_surrounding {
+                None => Span::styled("  ", self.default_bg()),
+                Some(s) => {
+                    let style = self
+                        .default_style
+                        .patch(s)
+                        .patch(self.events.get_style(date));
+                    Span::styled(format!("{:2?}", date.day()), style)
+                }
+            }
+        } else {
+            Span::styled(
+                format!("{:2?}", date.day()),
+                self.default_style.patch(self.events.get_style(date)),
+            )
+        }
+    }
+}
+
+impl<'a, S: DateStyler> Widget for Monthly<'a, S> {
+    fn render(mut self, area: Rect, buf: &mut Buffer) {
+        // Block is used for borders and such
+        // Draw that first, and use the blank area inside the block for our own purposes
+        let mut area = match self.block.take() {
+            None => area,
+            Some(b) => {
+                let inner = b.inner(area);
+                b.render(area, buf);
+                inner
+            }
+        };
+
+        // Draw the month name and year
+        if let Some(style) = self.show_month {
+            let line = Span::styled(
+                format!("{} {}", self.display_date.month(), self.display_date.year()),
+                style,
+            );
+            // cal is 21 cells wide, so hard code the 11
+            let x_off = 11_u16.saturating_sub(line.width() as u16 / 2);
+            buf.set_spans(area.x + x_off, area.y, &line.into(), area.width);
+            area.y += 1
+        }
+
+        // Draw days of week
+        if let Some(style) = self.show_weekday {
+            let days = String::from(" Su Mo Tu We Th Fr Sa");
+            buf.set_string(area.x, area.y, days, style);
+            area.y += 1;
+        }
+
+        // Set the start of the calendar to the Sunday before the 1st (or the sunday of the first)
+        let first_of_month = self.display_date.replace_day(1).unwrap();
+        let offset = Duration::days(first_of_month.weekday().number_days_from_sunday().into());
+        let mut curr_day = first_of_month - offset;
+
+        // go through all the weeks containing a day in the target month.
+        while curr_day.month() as u8 != self.display_date.month().next() as u8 {
+            let mut line = Spans(Vec::with_capacity(14));
+            for i in 0..7 {
+                // Draw the gutter. Do it here so we can avoid worrying about
+                // styling the ' ' in the format_date method
+                if i == 0 {
+                    line.0.push(Span::styled(" ", Style::default()));
+                } else {
+                    line.0.push(Span::styled(" ", self.default_bg()));
+                }
+                line.0.push(self.format_date(curr_day));
+                curr_day += Duration::DAY;
+            }
+            buf.set_spans(area.x, area.y, &line, area.width);
+            area.y += 1;
+        }
+    }
+}
+
+/// Provides a method for styling a given date. [Month] is generic on this trait, so any type
+/// that implements this trait can be used.
+pub trait DateStyler {
+    /// Given a date, return a style for that date
+    fn get_style(&self, date: Date) -> Style;
+}
+
+/// A simple DateStyler based on a [HashMap]
+pub struct CalendarEventStore(pub HashMap<Date, Style>);
+
+impl CalendarEventStore {
+    /// Construct a store that has the current date styled.
+    pub fn today(style: Style) -> Self {
+        let mut res = Self::default();
+        res.add(OffsetDateTime::now_local().unwrap().date(), style);
+        res
+    }
+
+    /// Add a date and style to the store
+    pub fn add(&mut self, date: Date, style: Style) {
+        // to simplify style nonsense, last write wins
+        let _ = self.0.insert(date, style);
+    }
+
+    /// Helper for trait impls
+    fn lookup_style(&self, date: Date) -> Style {
+        self.0.get(&date).copied().unwrap_or_default()
+    }
+}
+
+impl DateStyler for CalendarEventStore {
+    fn get_style(&self, date: Date) -> Style {
+        self.lookup_style(date)
+    }
+}
+
+impl DateStyler for &CalendarEventStore {
+    fn get_style(&self, date: Date) -> Style {
+        self.lookup_style(date)
+    }
+}
+
+impl Default for CalendarEventStore {
+    fn default() -> Self {
+        Self(HashMap::with_capacity(4))
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -13,10 +13,13 @@
 //! - [`BarChart`]
 //! - [`Gauge`]
 //! - [`Sparkline`]
+//! - [`calendar::Monthly`]
 //! - [`Clear`]
 
 mod barchart;
 mod block;
+#[cfg(feature = "widget-calendar")]
+pub mod calendar;
 pub mod canvas;
 mod chart;
 mod clear;

--- a/tests/widgets_calendar.rs
+++ b/tests/widgets_calendar.rs
@@ -1,0 +1,114 @@
+#![cfg(feature = "widget-calendar")]
+use ratatui::{
+    backend::TestBackend,
+    buffer::Buffer,
+    style::Style,
+    widgets::{
+        calendar::{CalendarEventStore, Monthly},
+        Widget,
+    },
+    Terminal,
+};
+
+use time::{Date, Month};
+
+fn test_render<W: Widget>(widget: W, expected: Buffer, size: (u16, u16)) {
+    let backend = TestBackend::new(size.0, size.1);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    terminal
+        .draw(|f| f.render_widget(widget, f.size()))
+        .unwrap();
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn days_layout() {
+    let c = Monthly::new(
+        Date::from_calendar_date(2023, Month::January, 1).unwrap(),
+        CalendarEventStore::default(),
+    );
+    let expected = Buffer::with_lines(vec![
+        "  1  2  3  4  5  6  7",
+        "  8  9 10 11 12 13 14",
+        " 15 16 17 18 19 20 21",
+        " 22 23 24 25 26 27 28",
+        " 29 30 31",
+    ]);
+    test_render(c, expected, (21, 5));
+}
+
+#[test]
+fn days_layout_show_surrounding() {
+    let c = Monthly::new(
+        Date::from_calendar_date(2023, Month::December, 1).unwrap(),
+        CalendarEventStore::default(),
+    )
+    .show_surrounding(Style::default());
+    let expected = Buffer::with_lines(vec![
+        " 26 27 28 29 30  1  2",
+        "  3  4  5  6  7  8  9",
+        " 10 11 12 13 14 15 16",
+        " 17 18 19 20 21 22 23",
+        " 24 25 26 27 28 29 30",
+        " 31  1  2  3  4  5  6",
+    ]);
+    test_render(c, expected, (21, 6));
+}
+
+#[test]
+fn show_month_header() {
+    let c = Monthly::new(
+        Date::from_calendar_date(2023, Month::January, 1).unwrap(),
+        CalendarEventStore::default(),
+    )
+    .show_month_header(Style::default());
+    let expected = Buffer::with_lines(vec![
+        "     January 2023    ",
+        "  1  2  3  4  5  6  7",
+        "  8  9 10 11 12 13 14",
+        " 15 16 17 18 19 20 21",
+        " 22 23 24 25 26 27 28",
+        " 29 30 31",
+    ]);
+    test_render(c, expected, (21, 6));
+}
+
+#[test]
+fn show_weekdays_header() {
+    let c = Monthly::new(
+        Date::from_calendar_date(2023, Month::January, 1).unwrap(),
+        CalendarEventStore::default(),
+    )
+    .show_weekdays_header(Style::default());
+    let expected = Buffer::with_lines(vec![
+        " Su Mo Tu We Th Fr Sa",
+        "  1  2  3  4  5  6  7",
+        "  8  9 10 11 12 13 14",
+        " 15 16 17 18 19 20 21",
+        " 22 23 24 25 26 27 28",
+        " 29 30 31",
+    ]);
+    test_render(c, expected, (21, 6));
+}
+
+#[test]
+fn show_combo() {
+    let c = Monthly::new(
+        Date::from_calendar_date(2023, Month::January, 1).unwrap(),
+        CalendarEventStore::default(),
+    )
+    .show_weekdays_header(Style::default())
+    .show_month_header(Style::default())
+    .show_surrounding(Style::default());
+    let expected = Buffer::with_lines(vec![
+        "     January 2023    ",
+        " Su Mo Tu We Th Fr Sa",
+        "  1  2  3  4  5  6  7",
+        "  8  9 10 11 12 13 14",
+        " 15 16 17 18 19 20 21",
+        " 22 23 24 25 26 27 28",
+        " 29 30 31  1  2  3  4",
+    ]);
+    test_render(c, expected, (21, 7));
+}


### PR DESCRIPTION
A calendar widget that with some display options and styling for individual dates.

This widget displays the month provided to it in the constructor. (see docs and the example for more info).

One thing to note: This pulls in a new dependency, the [time](https://crates.io/crates/time) crate. Since this adds a dependency, it might be worth putting the widget behind a feature flag - I'm happy to do so if that's desired.