### PR TITLE
refactor(examples): refactor paragraph example

### DIFF
--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -95,7 +95,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
     let mut long_line = s.repeat(usize::from(size.width) / s.len() + 4);
     long_line.push('\n');
 
-    let block = Block::default().style(Style::default().bg(Color::White).fg(Color::Black));
+    let block = Block::default().style(Style::default().fg(Color::Black));
     f.render_widget(block, size);
 
     let chunks = Layout::default()
@@ -138,32 +138,36 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
     let create_block = |title| {
         Block::default()
             .borders(Borders::ALL)
-            .style(Style::default().bg(Color::White).fg(Color::Black))
+            .style(Style::default().fg(Color::Gray))
             .title(Span::styled(
                 title,
                 Style::default().add_modifier(Modifier::BOLD),
             ))
     };
+
     let paragraph = Paragraph::new(text.clone())
-        .style(Style::default().bg(Color::White).fg(Color::Black))
+        .style(Style::default().fg(Color::Gray))
         .block(create_block("Left, no wrap"))
         .alignment(Alignment::Left);
     f.render_widget(paragraph, chunks[0]);
+
     let paragraph = Paragraph::new(text.clone())
-        .style(Style::default().bg(Color::White).fg(Color::Black))
+        .style(Style::default().fg(Color::Gray))
         .block(create_block("Left, wrap"))
         .alignment(Alignment::Left)
         .wrap(Wrap { trim: true });
     f.render_widget(paragraph, chunks[1]);
+
     let paragraph = Paragraph::new(text.clone())
-        .style(Style::default().bg(Color::White).fg(Color::Black))
+        .style(Style::default().fg(Color::Gray))
         .block(create_block("Center, wrap"))
         .alignment(Alignment::Center)
         .wrap(Wrap { trim: true })
         .scroll((app.scroll, 0));
     f.render_widget(paragraph, chunks[2]);
+
     let paragraph = Paragraph::new(text)
-        .style(Style::default().bg(Color::White).fg(Color::Black))
+        .style(Style::default().fg(Color::Gray))
         .block(create_block("Right, wrap"))
         .alignment(Alignment::Right)
         .wrap(Wrap { trim: true });

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -100,7 +100,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .margin(5)
+        .margin(2)
         .constraints(
             [
                 Constraint::Percentage(25),

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -147,29 +147,27 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
 
     let paragraph = Paragraph::new(text.clone())
         .style(Style::default().fg(Color::Gray))
-        .block(create_block("Left, no wrap"))
-        .alignment(Alignment::Left);
+        .block(create_block("Default alignment (Left), no wrap"));
     f.render_widget(paragraph, chunks[0]);
 
     let paragraph = Paragraph::new(text.clone())
         .style(Style::default().fg(Color::Gray))
-        .block(create_block("Left, wrap"))
-        .alignment(Alignment::Left)
+        .block(create_block("Default alignment (Left), with wrap"))
         .wrap(Wrap { trim: true });
     f.render_widget(paragraph, chunks[1]);
 
     let paragraph = Paragraph::new(text.clone())
         .style(Style::default().fg(Color::Gray))
-        .block(create_block("Center, wrap"))
-        .alignment(Alignment::Center)
-        .wrap(Wrap { trim: true })
-        .scroll((app.scroll, 0));
+        .block(create_block("Right alignment, with wrap"))
+        .alignment(Alignment::Right)
+        .wrap(Wrap { trim: true });
     f.render_widget(paragraph, chunks[2]);
 
     let paragraph = Paragraph::new(text)
         .style(Style::default().fg(Color::Gray))
-        .block(create_block("Right, wrap"))
-        .alignment(Alignment::Right)
-        .wrap(Wrap { trim: true });
+        .block(create_block("Center alignment, with wrap, with scroll"))
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: true })
+        .scroll((app.scroll, 0));
     f.render_widget(paragraph, chunks[3]);
 }


### PR DESCRIPTION
While looking at #33 I opened the paragraph example and almost lost my eyesight with the white background haha. So anyways this PR brings minor tweaks aiming to make the example easier on the eyes, as well as a couple minor changes.

**Changes :**
- Background color not set anymore
- Text foreground color changed to gray (seemed like the most sensible option that would suit both light and dark theme users)
- Moved scroll example to last chunk
- Reworked block names