### PR TITLE
feat(widget_list): implement WidgetList #132

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 *.rs.rustfmt
 .gdb_history
 .idea/
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,3 +140,7 @@ doc-scrape-examples = true
 name = "inline"
 required-features = ["crossterm"]
 doc-scrape-examples = true
+
+[[example]]
+name = "widget_list"
+required-features = ["crossterm"]

--- a/examples/widget_list.rs
+++ b/examples/widget_list.rs
@@ -1,0 +1,710 @@
+use crossterm::{
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{
+        BarChart, Block, Borders, Gauge, ListItem, Paragraph, WidgetList, WidgetListItem3,
+        WidgetListState, Wrap,
+    },
+    Frame, Terminal,
+};
+use std::{
+    error::Error,
+    io,
+    time::{Duration, Instant},
+};
+
+struct StatefulList<T> {
+    state: WidgetListState,
+    items: Vec<T>,
+}
+
+impl<T> StatefulList<T> {
+    fn with_items(items: Vec<T>) -> StatefulList<T> {
+        StatefulList {
+            state: WidgetListState::default(),
+            items,
+        }
+    }
+
+    fn next(&mut self) {
+        let i = match self.state.selected() {
+            Some(i) => {
+                if i >= self.items.len() - 1 {
+                    0
+                } else {
+                    i + 1
+                }
+            }
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    fn previous(&mut self) {
+        let i = match self.state.selected() {
+            Some(i) => {
+                if i == 0 {
+                    self.items.len() - 1
+                } else {
+                    i - 1
+                }
+            }
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    /*fn unselect(&mut self) {
+        self.state.select(None);
+    }*/
+}
+
+const LIST_COUNT: usize = 7;
+const EDITABLE_PARAGRAPH_LIST_INDEX: usize = 6;
+
+enum WidgetListItemData<'a> {
+    Paragraph((&'a str, usize)),
+    Gauge(&'a str),
+    BarChart(Vec<(&'a str, u64)>),
+}
+
+type WidgetCustomItem<'a> = WidgetListItem3<Paragraph<'a>, Gauge<'a>, BarChart<'a>>;
+
+macro_rules! is_selected {
+    ($list:expr, $index:expr) => {
+        if let Some(selected) = $list.state.selected() {
+            $index == selected
+        } else {
+            false
+        }
+    };
+}
+
+/// This struct holds the current state of the app. In particular, it has the `items` field which is a wrapper
+/// around `ListState`. Keeping track of the items state let us render the associated widget with its state
+/// and have access to features such as natural scrolling.
+///
+/// Check the event handling at the bottom to see how to change the state on incoming events.
+/// Check the drawing logic for items on how to specify the highlighting style for selected items.
+struct App<'a> {
+    selected_list: usize,
+    paragraphs: StatefulList<(&'a str, usize)>,
+    texts: StatefulList<(&'a str, usize)>,
+    gauges: StatefulList<&'a str>,
+    barcharts: StatefulList<(&'a str, u64)>,
+    widget_items: StatefulList<WidgetListItemData<'a>>,
+    widget_items_filled: StatefulList<WidgetListItemData<'a>>,
+    editable_paragraphs: StatefulList<String>,
+}
+
+impl<'a> App<'a> {
+    fn new() -> App<'a> {
+        App {
+            paragraphs: StatefulList::with_items(vec![
+                ("Item0", 6),
+                ("Item1", 6),
+                ("Item2", 1),
+                ("Item3", 3),
+                ("Item4", 1),
+                ("Item5", 2),
+                ("Item6", 1),
+                ("Item7", 3),
+                ("Item8", 1),
+                ("Item9", 6),
+                ("Item10", 1),
+                ("Item11", 3),
+                ("Item12", 1),
+                ("Item13", 2),
+                ("Item14", 1),
+                ("Item15", 1),
+                ("Item16", 4),
+                ("Item17", 1),
+                ("Item18", 5),
+                ("Item19", 4),
+                ("Item20", 1),
+                ("Item21", 2),
+                ("Item22", 1),
+                ("Item23", 3),
+                ("Item24", 1),
+            ]),
+            texts: StatefulList::with_items(vec![
+                ("Item0", 6),
+                ("Item1", 6),
+                ("Item2", 1),
+                ("Item3", 3),
+                ("Item4", 1),
+                ("Item5", 2),
+                ("Item6", 1),
+                ("Item7", 3),
+                ("Item8", 1),
+                ("Item9", 6),
+                ("Item10", 1),
+                ("Item11", 3),
+                ("Item12", 1),
+                ("Item13", 2),
+                ("Item14", 1),
+                ("Item15", 1),
+                ("Item16", 4),
+                ("Item17", 1),
+                ("Item18", 5),
+                ("Item19", 4),
+                ("Item20", 1),
+                ("Item21", 2),
+                ("Item22", 1),
+                ("Item23", 3),
+                ("Item24", 1),
+            ]),
+            gauges: StatefulList::with_items(vec![
+                "Event1", "Event2", "Event3", "Event4", "Event5", "Event6", "Event7", "Event8",
+                "Event9", "Event10", "Event11", "Event12",
+            ]),
+            barcharts: StatefulList::with_items(vec![
+                ("B1", 9),
+                ("B2", 12),
+                ("B3", 5),
+                ("B4", 8),
+                ("B5", 2),
+                ("B6", 4),
+                ("B7", 5),
+                ("B8", 9),
+                ("B9", 14),
+                ("B10", 15),
+                ("B11", 1),
+                ("B12", 0),
+                ("B13", 4),
+                ("B14", 6),
+            ]),
+            widget_items: StatefulList::with_items(vec![
+                WidgetListItemData::Paragraph(("title1", 3)),
+                WidgetListItemData::Gauge("Gauge1"),
+                WidgetListItemData::BarChart(vec![
+                    ("B1", 9),
+                    ("B2", 12),
+                    ("B3", 5),
+                    ("B4", 8),
+                    ("B5", 2),
+                    ("B6", 4),
+                    ("B7", 5),
+                    ("B8", 9),
+                    ("B9", 14),
+                    ("B10", 15),
+                ]),
+                WidgetListItemData::Paragraph(("title1", 6)),
+                WidgetListItemData::Gauge("Gauge7"),
+            ]),
+            widget_items_filled: StatefulList::with_items(vec![
+                WidgetListItemData::Paragraph(("title1", 3)),
+                WidgetListItemData::Gauge("Gauge1"),
+                WidgetListItemData::BarChart(vec![
+                    ("B1", 9),
+                    ("B2", 12),
+                    ("B3", 5),
+                    ("B4", 8),
+                    ("B5", 2),
+                    ("B6", 4),
+                    ("B7", 5),
+                    ("B8", 9),
+                    ("B9", 14),
+                    ("B10", 15),
+                ]),
+                WidgetListItemData::Paragraph(("title1", 6)),
+                WidgetListItemData::Gauge("Gauge7"),
+            ]),
+            editable_paragraphs: StatefulList::with_items(vec![
+                "write to edit this text 0".to_string(),
+                "write to edit this text 1".to_string(),
+                "write to edit this text 2".to_string(),
+                "write to edit this text 3".to_string(),
+                "write to edit this text 4".to_string(),
+                "write to edit this text 5".to_string(),
+            ]),
+            selected_list: 0,
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // create app and run it
+    let tick_rate = Duration::from_millis(250);
+    let app = App::new();
+    let res = run_app(&mut terminal, app, tick_rate);
+
+    // restore terminal
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+
+    if let Err(err) = res {
+        println!("{:?}", err)
+    }
+
+    Ok(())
+}
+
+fn run_app<B: Backend>(
+    terminal: &mut Terminal<B>,
+    mut app: App,
+    tick_rate: Duration,
+) -> io::Result<()> {
+    let mut last_tick = Instant::now();
+    loop {
+        terminal.draw(|f| ui(f, &mut app))?;
+
+        let timeout = tick_rate
+            .checked_sub(last_tick.elapsed())
+            .unwrap_or_else(|| Duration::from_secs(0));
+        if crossterm::event::poll(timeout)? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind == KeyEventKind::Press {
+                    match key.code {
+                        KeyCode::Char('q') => {
+                            if app.selected_list == EDITABLE_PARAGRAPH_LIST_INDEX {
+                                if let Some(selected) = app.editable_paragraphs.state.selected() {
+                                    app.editable_paragraphs.items[selected].push('q');
+                                } else {
+                                    return Ok(());
+                                }
+                            } else {
+                                return Ok(());
+                            }
+                        }
+                        KeyCode::Left => app.selected_list = app.selected_list.saturating_sub(1),
+                        KeyCode::Right => {
+                            if app.selected_list < LIST_COUNT - 1 {
+                                app.selected_list += 1
+                            }
+                        }
+                        KeyCode::Down => match app.selected_list {
+                            0 => app.paragraphs.next(),
+                            1 => app.texts.next(),
+                            2 => app.gauges.next(),
+                            3 => app.barcharts.next(),
+                            4 => app.widget_items.next(),
+                            5 => app.widget_items_filled.next(),
+                            6 => app.editable_paragraphs.next(),
+                            _ => {}
+                        },
+                        KeyCode::Up => match app.selected_list {
+                            0 => app.paragraphs.previous(),
+                            1 => app.texts.previous(),
+                            2 => app.gauges.previous(),
+                            3 => app.barcharts.previous(),
+                            4 => app.widget_items.previous(),
+                            5 => app.widget_items_filled.previous(),
+                            6 => app.editable_paragraphs.previous(),
+                            _ => {}
+                        },
+                        KeyCode::Char(ch) => {
+                            if app.selected_list == EDITABLE_PARAGRAPH_LIST_INDEX {
+                                if let Some(selected) = app.editable_paragraphs.state.selected() {
+                                    app.editable_paragraphs.items[selected].push(ch);
+                                }
+                            }
+                        }
+                        KeyCode::Backspace => {
+                            if app.selected_list == EDITABLE_PARAGRAPH_LIST_INDEX {
+                                if let Some(selected) = app.editable_paragraphs.state.selected() {
+                                    app.editable_paragraphs.items[selected].pop();
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        if last_tick.elapsed() >= tick_rate {
+            last_tick = Instant::now();
+        }
+    }
+}
+
+fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App) {
+    // Create two chunks with equal horizontal screen space
+    let vertical_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+        .split(f.size());
+
+    let row0_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(
+            [
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+            ]
+            .as_ref(),
+        )
+        .split(vertical_chunks[0]);
+
+    let row1_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(
+            [
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+            ]
+            .as_ref(),
+        )
+        .split(vertical_chunks[1]);
+
+    create_paragraph_list(
+        f,
+        &mut app.paragraphs,
+        row0_chunks[0],
+        app.selected_list == 0,
+    );
+    create_text_list(f, &mut app.texts, row0_chunks[1], app.selected_list == 1);
+    create_gauge_list(f, &mut app.gauges, row0_chunks[2], app.selected_list == 2);
+    create_barchart_list(
+        f,
+        &mut app.barcharts,
+        row0_chunks[3],
+        app.selected_list == 3,
+    );
+    create_widget_item_list(
+        f,
+        &mut app.widget_items,
+        row1_chunks[0],
+        app.selected_list == 4,
+        false,
+    );
+    create_widget_item_list(
+        f,
+        &mut app.widget_items_filled,
+        row1_chunks[1],
+        app.selected_list == 5,
+        true,
+    );
+
+    create_editable_paragraph_list(
+        f,
+        &mut app.editable_paragraphs,
+        row1_chunks[2],
+        app.selected_list == EDITABLE_PARAGRAPH_LIST_INDEX,
+    );
+}
+
+fn get_border_style(is_selected: bool) -> Style {
+    if is_selected {
+        Style::default().fg(Color::Red)
+    } else {
+        Style::default()
+    }
+}
+
+fn create_paragraph<'a>(is_selected: bool, data: &'a (&str, usize)) -> Paragraph<'a> {
+    let mut lines = vec![Line::from(data.0)];
+    for index in 0..data.1 {
+        lines.push(Line::from(Span::styled(
+            format!(
+                "[{}/{}] Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                index + 1,
+                data.1
+            ),
+            Style::default().add_modifier(Modifier::ITALIC),
+        )));
+    }
+
+    let mut style = Style::default().fg(Color::Black).bg(Color::White);
+    if is_selected {
+        style = style.bg(Color::LightGreen).add_modifier(Modifier::BOLD)
+    }
+
+    Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .style(style)
+}
+
+fn create_paragraph_list<B: Backend>(
+    f: &mut Frame<B>,
+    list: &mut StatefulList<(&str, usize)>,
+    area: Rect,
+    is_selected: bool,
+) {
+    // Iterate through all elements in the `items` app and append some debug text to it.
+    let items: Vec<Paragraph> = list
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, data)| create_paragraph(is_selected!(list, index), data))
+        .collect();
+
+    // Create a List from all list items and highlight the currently selected one
+    let items = WidgetList::new(items)
+        .spacing(1)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("paragraphs")
+                .border_style(get_border_style(is_selected)),
+        )
+        .highlight_symbol(">> ");
+
+    // We can now render the item list
+    f.render_stateful_widget(items, area, &mut list.state);
+}
+
+fn create_text_list<B: Backend>(
+    f: &mut Frame<B>,
+    list: &mut StatefulList<(&str, usize)>,
+    area: Rect,
+    is_selected: bool,
+) {
+    // Iterate through all elements in the `items` app and append some debug text to it.
+    let items: Vec<ListItem> = list
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, data)| {
+            let mut lines = vec![Line::from(data.0)];
+            for index in 0..data.1 {
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "[{}/{}] Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                        index + 1,
+                        data.1
+                    ),
+                    Style::default().add_modifier(Modifier::ITALIC),
+                )));
+            }
+
+            let mut style = Style::default().fg(Color::Black).bg(Color::White);
+            if let Some(selected) = list.state.selected() {
+                if index == selected {
+                    style = style.bg(Color::LightGreen).add_modifier(Modifier::BOLD)
+                }
+            }
+
+            ListItem::new(lines).style(style)
+        })
+        .collect();
+
+    // Create a List from all list items and highlight the currently selected one
+    let items = WidgetList::new(items)
+        .spacing(1)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("texts")
+                .border_style(get_border_style(is_selected)),
+        )
+        .highlight_symbol(">> ")
+        .repeat_highlight_symbol(true);
+
+    // We can now render the item list
+    f.render_stateful_widget(items, area, &mut list.state);
+}
+
+fn create_gauge<'a, T>(title: T, is_selected: bool, create_block: bool) -> Gauge<'a>
+where
+    T: Into<Line<'a>>,
+{
+    let mut gauge = Gauge::default()
+        .gauge_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::ITALIC),
+        )
+        .percent(50);
+
+    if is_selected || create_block {
+        gauge = gauge
+            .percent(100)
+            .block(Block::default().title(title).borders(Borders::ALL));
+
+        if is_selected {
+            gauge = gauge.percent(100).gauge_style(
+                Style::default()
+                    .fg(Color::LightGreen)
+                    .add_modifier(Modifier::ITALIC),
+            )
+        }
+    }
+
+    gauge
+}
+
+fn create_gauge_list<B: Backend>(
+    f: &mut Frame<B>,
+    list: &mut StatefulList<&str>,
+    area: Rect,
+    is_selected: bool,
+) {
+    let gauges: Vec<Gauge> = list
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, &title)| create_gauge(title, is_selected!(list, index), false))
+        .collect();
+
+    let item_len = gauges.len();
+    let gauge_list = WidgetList::new(gauges)
+        .spacing(1)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("gauges")
+                .border_style(get_border_style(is_selected)),
+        )
+        .item_heights(vec![Some(Constraint::Max(1)); item_len]); // Shrink
+    f.render_stateful_widget(gauge_list, area, &mut list.state);
+}
+
+fn create_barchart<'a>(title: String, is_selected: bool, data: &'a [(&str, u64)]) -> BarChart<'a> {
+    let mut barchart = BarChart::default()
+        .block(Block::default().title(title).borders(Borders::ALL))
+        .data(data)
+        .bar_style(Style::default().fg(Color::Yellow))
+        .value_style(Style::default().fg(Color::Black).bg(Color::Yellow));
+
+    if is_selected {
+        barchart = barchart.bar_style(Style::default().fg(Color::LightGreen));
+    }
+    barchart
+}
+
+fn create_barchart_list<B: Backend>(
+    f: &mut Frame<B>,
+    list: &mut StatefulList<(&str, u64)>,
+    area: Rect,
+    is_selected: bool,
+) {
+    let charts: Vec<BarChart> = (0..15)
+        .map(|index| {
+            create_barchart(
+                format!("Data{}", index),
+                is_selected!(list, index),
+                &list.items,
+            )
+        })
+        .collect();
+
+    let item_len = charts.len();
+    let chart_list = WidgetList::new(charts)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Barcharts")
+                .border_style(get_border_style(is_selected)),
+        )
+        .item_heights(vec![Some(Constraint::Max(5)); item_len]);
+    f.render_stateful_widget(chart_list, area, &mut list.state);
+}
+
+fn create_widget_item_list<B: Backend>(
+    f: &mut Frame<B>,
+    list: &mut StatefulList<WidgetListItemData>,
+    area: Rect,
+    is_selected: bool,
+    fill_content: bool,
+) {
+    let (charts, constraints): (Vec<WidgetCustomItem>, Vec<Option<Constraint>>) = list
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            let is_selected = is_selected!(list, index);
+
+            match item {
+                WidgetListItemData::Paragraph(d) => (
+                    WidgetCustomItem::One(create_paragraph(is_selected, d)),
+                    None,
+                ),
+                WidgetListItemData::Gauge(d) => (
+                    WidgetCustomItem::Two(create_gauge(*d, is_selected, true)),
+                    Some(Constraint::Max(1)), // equivalent to Shrink
+                ),
+                WidgetListItemData::BarChart(d) => (
+                    WidgetCustomItem::Three(create_barchart("Chart".to_string(), is_selected, d)),
+                    Some(Constraint::Max(5)),
+                ),
+            }
+        })
+        .unzip();
+
+    let mixed_list = WidgetList::new(charts)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Mixed")
+                .border_style(get_border_style(is_selected)),
+        )
+        .item_heights(if fill_content {
+            // Fill the view
+            vec![Some(Constraint::Min(area.height.saturating_sub(2))); constraints.len()]
+        } else {
+            constraints
+        });
+
+    f.render_stateful_widget(mixed_list, area, &mut list.state);
+}
+
+fn create_editable_paragraph(is_selected: bool, data: &str) -> Paragraph {
+    let lines = vec![if is_selected {
+        Line::from(vec![
+            Span::raw(data),
+            Span::styled("█", Style::default().fg(Color::Red)),
+        ])
+    } else {
+        Line::from(data)
+    }];
+
+    let mut style = Style::default().fg(Color::Black).bg(Color::White);
+    if is_selected {
+        style = style.bg(Color::LightGreen).add_modifier(Modifier::BOLD);
+    }
+
+    Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .block(Block::default().borders(Borders::all()))
+        .style(style)
+}
+
+fn create_editable_paragraph_list<B: Backend>(
+    f: &mut Frame<B>,
+    list: &mut StatefulList<String>,
+    area: Rect,
+    is_selected: bool,
+) {
+    // Iterate through all elements in the `items` app and append some debug text to it.
+    let items: Vec<Paragraph> = list
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, data)| create_editable_paragraph(is_selected!(list, index), data))
+        .collect();
+
+    // Create a List from all list items and highlight the currently selected one
+    let items = WidgetList::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("editable paragraphs")
+            .border_style(get_border_style(is_selected)),
+    );
+
+    // We can now render the item list
+    f.render_stateful_widget(items, area, &mut list.state);
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -379,6 +379,18 @@ impl Element {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct Size {
+    pub width: u16,
+    pub height: u16,
+}
+
+impl Size {
+    pub fn new(width: u16, height: u16) -> Self {
+        Self { width, height }
+    }
+}
+
 /// A simple rectangle used in the computation of the layout and to give widgets a hint about the
 /// area they are supposed to render to.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]

--- a/src/widgets/barchart.rs
+++ b/src/widgets/barchart.rs
@@ -1,12 +1,14 @@
 use crate::{
     buffer::Buffer,
-    layout::Rect,
+    layout::{Rect, Size},
     style::Style,
     symbols,
     widgets::{Block, Widget},
 };
 use std::cmp::min;
 use unicode_width::UnicodeWidthStr;
+
+use super::SizeHint;
 
 /// Display multiple bars in a single widgets
 ///
@@ -214,6 +216,21 @@ impl<'a> Widget for BarChart<'a> {
                 self.bar_width as usize,
                 self.label_style,
             );
+        }
+    }
+}
+
+impl<'a> SizeHint for BarChart<'a> {
+    fn size_hint(&self, area: &Rect) -> Size {
+        match &self.block {
+            Some(b) => {
+                let block_area = b.size_hint(&Rect::default());
+                Size::new(
+                    area.width.max(block_area.width),
+                    area.height.max(block_area.height + 1),
+                )
+            }
+            None => Size::new(area.width, area.height),
         }
     }
 }

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -1,11 +1,13 @@
 use crate::{
     buffer::Buffer,
-    layout::{Alignment, Rect},
+    layout::{Alignment, Rect, Size},
     style::Style,
     symbols::line,
     text::{Line, Span},
     widgets::{Borders, Widget},
 };
+
+use super::SizeHint;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BorderType {
@@ -339,6 +341,38 @@ impl<'a> Widget for Block<'a> {
 
             buf.set_line(title_x, title_y, &title, title_area_width);
         }
+    }
+}
+
+impl<'a> SizeHint for Block<'a> {
+    fn size_hint(&self, area: &Rect) -> Size {
+        let mut size = Size::default();
+
+        if self.borders.intersects(Borders::LEFT) {
+            size.width += 1;
+        }
+        if self.borders.intersects(Borders::TOP) || self.title.is_some() {
+            size.height += 1;
+        }
+        if self.borders.intersects(Borders::RIGHT) {
+            size.width += 1;
+        }
+        if self.borders.intersects(Borders::BOTTOM) {
+            size.height += 1;
+        }
+
+        size.width = size
+            .width
+            .saturating_add(self.padding.left)
+            .saturating_add(self.padding.right);
+        size.height = size
+            .height
+            .saturating_add(self.padding.top)
+            .saturating_add(self.padding.bottom);
+        size.width = size.width.max(area.width);
+        size.height = size.height.max(area.height);
+
+        size
     }
 }
 

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -1,11 +1,13 @@
 use crate::{
     buffer::Buffer,
-    layout::Rect,
+    layout::{Rect, Size},
     style::{Color, Style},
     symbols,
     text::{Line, Span},
     widgets::{Block, Widget},
 };
+
+use super::SizeHint;
 
 /// A widget to display a task progress.
 ///
@@ -140,6 +142,21 @@ impl<'a> Widget for Gauge<'a> {
         }
         // set the line
         buf.set_span(label_col, label_row, &label, clamped_label_width);
+    }
+}
+
+impl<'a> SizeHint for Gauge<'a> {
+    fn size_hint(&self, area: &Rect) -> Size {
+        match &self.block {
+            Some(b) => {
+                let block_area = b.size_hint(&Rect::default());
+                Size::new(
+                    area.width.max(block_area.width),
+                    area.height.max(block_area.height + 1),
+                )
+            }
+            None => Size::new(area.width, area.height),
+        }
     }
 }
 

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -1,50 +1,14 @@
 use crate::{
     buffer::Buffer,
-    layout::{Corner, Rect, Size},
+    layout::{Rect, Size},
     style::Style,
     text::Text,
-    widgets::{Block, StatefulWidget, Widget},
+    widgets::Widget,
 };
-use unicode_width::UnicodeWidthStr;
 
-use super::SizeHint;
+use super::{SizeHint, WidgetList, WidgetListState};
 
-#[derive(Debug, Clone, Default)]
-pub struct ListState {
-    offset: usize,
-    selected: Option<usize>,
-}
-
-impl ListState {
-    pub fn offset(&self) -> usize {
-        self.offset
-    }
-
-    pub fn offset_mut(&mut self) -> &mut usize {
-        &mut self.offset
-    }
-
-    pub fn with_selected(mut self, selected: Option<usize>) -> Self {
-        self.selected = selected;
-        self
-    }
-
-    pub fn with_offset(mut self, offset: usize) -> Self {
-        self.offset = offset;
-        self
-    }
-
-    pub fn selected(&self) -> Option<usize> {
-        self.selected
-    }
-
-    pub fn select(&mut self, index: Option<usize>) {
-        self.selected = index;
-        if index.is_none() {
-            self.offset = 0;
-        }
-    }
-}
+pub type ListState = WidgetListState;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListItem<'a> {
@@ -88,8 +52,7 @@ impl<'a> SizeHint for ListItem<'a> {
 
 impl<'a> Widget for ListItem<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let item_style = self.style.patch(self.style);
-        buf.set_style(area, item_style);
+        buf.set_style(area, self.style);
 
         for (j, line) in self.content.lines.iter().enumerate() {
             buf.set_line(area.x, area.y + j as u16, line, area.width);
@@ -111,206 +74,7 @@ impl<'a> Widget for ListItem<'a> {
 ///     .highlight_style(Style::default().add_modifier(Modifier::ITALIC))
 ///     .highlight_symbol(">>");
 /// ```
-#[derive(Debug, Clone)]
-pub struct List<'a> {
-    block: Option<Block<'a>>,
-    items: Vec<ListItem<'a>>,
-    /// Style used as a base style for the widget
-    style: Style,
-    start_corner: Corner,
-    /// Style used to render selected item
-    highlight_style: Style,
-    /// Symbol in front of the selected item (Shift all items to the right)
-    highlight_symbol: Option<&'a str>,
-    /// Whether to repeat the highlight symbol for each line of the selected item
-    repeat_highlight_symbol: bool,
-}
-
-impl<'a> List<'a> {
-    pub fn new<T>(items: T) -> List<'a>
-    where
-        T: Into<Vec<ListItem<'a>>>,
-    {
-        List {
-            block: None,
-            style: Style::default(),
-            items: items.into(),
-            start_corner: Corner::TopLeft,
-            highlight_style: Style::default(),
-            highlight_symbol: None,
-            repeat_highlight_symbol: false,
-        }
-    }
-
-    pub fn block(mut self, block: Block<'a>) -> List<'a> {
-        self.block = Some(block);
-        self
-    }
-
-    pub fn style(mut self, style: Style) -> List<'a> {
-        self.style = style;
-        self
-    }
-
-    pub fn highlight_symbol(mut self, highlight_symbol: &'a str) -> List<'a> {
-        self.highlight_symbol = Some(highlight_symbol);
-        self
-    }
-
-    pub fn highlight_style(mut self, style: Style) -> List<'a> {
-        self.highlight_style = style;
-        self
-    }
-
-    pub fn repeat_highlight_symbol(mut self, repeat: bool) -> List<'a> {
-        self.repeat_highlight_symbol = repeat;
-        self
-    }
-
-    pub fn start_corner(mut self, corner: Corner) -> List<'a> {
-        self.start_corner = corner;
-        self
-    }
-
-    pub fn len(&self) -> usize {
-        self.items.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.items.is_empty()
-    }
-
-    fn get_items_bounds(
-        &self,
-        selected: Option<usize>,
-        offset: usize,
-        max_height: usize,
-    ) -> (usize, usize) {
-        let offset = offset.min(self.items.len().saturating_sub(1));
-        let mut start = offset;
-        let mut end = offset;
-        let mut height = 0;
-        for item in self.items.iter().skip(offset) {
-            if height + item.height() > max_height {
-                break;
-            }
-            height += item.height();
-            end += 1;
-        }
-
-        let selected = selected.unwrap_or(0).min(self.items.len() - 1);
-        while selected >= end {
-            height = height.saturating_add(self.items[end].height());
-            end += 1;
-            while height > max_height {
-                height = height.saturating_sub(self.items[start].height());
-                start += 1;
-            }
-        }
-        while selected < start {
-            start -= 1;
-            height = height.saturating_add(self.items[start].height());
-            while height > max_height {
-                end -= 1;
-                height = height.saturating_sub(self.items[end].height());
-            }
-        }
-        (start, end)
-    }
-}
-
-impl<'a> StatefulWidget for List<'a> {
-    type State = ListState;
-
-    fn render(mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        buf.set_style(area, self.style);
-        let list_area = match self.block.take() {
-            Some(b) => {
-                let inner_area = b.inner(area);
-                b.render(area, buf);
-                inner_area
-            }
-            None => area,
-        };
-
-        if list_area.width < 1 || list_area.height < 1 {
-            return;
-        }
-
-        if self.items.is_empty() {
-            return;
-        }
-        let list_height = list_area.height as usize;
-
-        let (start, end) = self.get_items_bounds(state.selected, state.offset, list_height);
-        state.offset = start;
-
-        let highlight_symbol = self.highlight_symbol.unwrap_or("");
-        let blank_symbol = " ".repeat(highlight_symbol.width());
-
-        let mut current_height = 0;
-        let has_selection = state.selected.is_some();
-        for (i, item) in self
-            .items
-            .iter_mut()
-            .enumerate()
-            .skip(state.offset)
-            .take(end - start)
-        {
-            let (x, y) = if self.start_corner == Corner::BottomLeft {
-                current_height += item.height() as u16;
-                (list_area.left(), list_area.bottom() - current_height)
-            } else {
-                let pos = (list_area.left(), list_area.top() + current_height);
-                current_height += item.height() as u16;
-                pos
-            };
-            let area = Rect {
-                x,
-                y,
-                width: list_area.width,
-                height: item.height() as u16,
-            };
-            let item_style = self.style.patch(item.style);
-            buf.set_style(area, item_style);
-
-            let is_selected = state.selected.map_or(false, |s| s == i);
-            for (j, line) in item.content.lines.iter().enumerate() {
-                // if the item is selected, we need to display the highlight symbol:
-                // - either for the first line of the item only,
-                // - or for each line of the item if the appropriate option is set
-                let symbol = if is_selected && (j == 0 || self.repeat_highlight_symbol) {
-                    highlight_symbol
-                } else {
-                    &blank_symbol
-                };
-                let (elem_x, max_element_width) = if has_selection {
-                    let (elem_x, _) = buf.set_stringn(
-                        x,
-                        y + j as u16,
-                        symbol,
-                        list_area.width as usize,
-                        item_style,
-                    );
-                    (elem_x, (list_area.width - (elem_x - x)))
-                } else {
-                    (x, list_area.width)
-                };
-                buf.set_line(elem_x, y + j as u16, line, max_element_width);
-            }
-            if is_selected {
-                buf.set_style(area, self.highlight_style);
-            }
-        }
-    }
-}
-
-impl<'a> Widget for List<'a> {
-    fn render(self, area: Rect, buf: &mut Buffer) {
-        let mut state = ListState::default();
-        StatefulWidget::render(self, area, buf, &mut state);
-    }
-}
+pub type List<'a> = WidgetList<'a, ListItem<'a>>;
 
 #[cfg(test)]
 mod tests {
@@ -318,9 +82,10 @@ mod tests {
 
     use crate::{
         assert_buffer_eq,
+        layout::Corner,
         style::Color,
         text::{Line, Span},
-        widgets::{Borders, StatefulWidget, Widget},
+        widgets::{Block, Borders, StatefulWidget, Widget},
     };
 
     use super::*;
@@ -340,16 +105,16 @@ mod tests {
     #[test]
     fn test_list_state_select() {
         let mut state = ListState::default();
-        assert_eq!(state.selected, None);
-        assert_eq!(state.offset, 0);
+        assert_eq!(state.selected(), None);
+        assert_eq!(state.offset(), 0);
 
         state.select(Some(2));
-        assert_eq!(state.selected, Some(2));
-        assert_eq!(state.offset, 0);
+        assert_eq!(state.selected(), Some(2));
+        assert_eq!(state.offset(), 0);
 
         state.select(None);
-        assert_eq!(state.selected, None);
-        assert_eq!(state.offset, 0);
+        assert_eq!(state.selected(), None);
+        assert_eq!(state.offset(), 0);
     }
 
     #[test]
@@ -876,9 +641,10 @@ mod tests {
 
         let expected = Buffer::with_lines(vec![">>Item 1  ", "  Item 2  ", "  Item 3  "]);
         assert_buffer_eq!(buffer, expected);
-        assert_eq!(state.selected, Some(1));
+        assert_eq!(state.selected(), Some(1));
         assert_eq!(
-            state.offset, 1,
+            state.offset(),
+            1,
             "did not scroll the selected item into view"
         );
     }
@@ -896,9 +662,10 @@ mod tests {
 
         let expected = Buffer::with_lines(vec!["  Item 4  ", "  Item 5  ", ">>Item 6  "]);
         assert_buffer_eq!(buffer, expected);
-        assert_eq!(state.selected, Some(6));
+        assert_eq!(state.selected(), Some(6));
         assert_eq!(
-            state.offset, 4,
+            state.offset(),
+            4,
             "did not scroll the selected item into view"
         );
     }

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -1,11 +1,13 @@
 use crate::{
     buffer::Buffer,
-    layout::{Corner, Rect},
+    layout::{Corner, Rect, Size},
     style::Style,
     text::Text,
     widgets::{Block, StatefulWidget, Widget},
 };
 use unicode_width::UnicodeWidthStr;
+
+use super::SizeHint;
 
 #[derive(Debug, Clone, Default)]
 pub struct ListState {
@@ -72,6 +74,26 @@ impl<'a> ListItem<'a> {
 
     pub fn width(&self) -> usize {
         self.content.width()
+    }
+}
+
+impl<'a> SizeHint for ListItem<'a> {
+    fn size_hint(&self, area: &Rect) -> Size {
+        Size::new(
+            area.width.min(self.content.width() as u16),
+            self.content.height() as u16,
+        )
+    }
+}
+
+impl<'a> Widget for ListItem<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let item_style = self.style.patch(self.style);
+        buf.set_style(area, item_style);
+
+        for (j, line) in self.content.lines.iter().enumerate() {
+            buf.set_line(area.x, area.y + j as u16, line, area.width);
+        }
     }
 }
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -44,7 +44,10 @@ pub use self::sparkline::{RenderDirection, Sparkline};
 pub use self::table::{Cell, Row, Table, TableState};
 pub use self::tabs::Tabs;
 
-use crate::{buffer::Buffer, layout::Rect};
+use crate::{
+    buffer::Buffer,
+    layout::{Rect, Size},
+};
 use bitflags::bitflags;
 
 bitflags! {
@@ -101,6 +104,10 @@ pub trait Widget {
     /// Draws the current state of the widget in the given buffer. That is the only method required
     /// to implement a custom widget.
     fn render(self, area: Rect, buf: &mut Buffer);
+}
+
+pub trait SizeHint {
+    fn size_hint(&self, area: &Rect) -> Size;
 }
 
 /// A `StatefulWidget` is a widget that can take advantage of some local state to remember things

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -30,6 +30,7 @@ mod reflow;
 mod sparkline;
 mod table;
 mod tabs;
+mod widget_list;
 
 use std::fmt::{self, Debug};
 
@@ -43,6 +44,7 @@ pub use self::paragraph::{Paragraph, Wrap};
 pub use self::sparkline::{RenderDirection, Sparkline};
 pub use self::table::{Cell, Row, Table, TableState};
 pub use self::tabs::Tabs;
+pub use self::widget_list::{WidgetList, WidgetListState};
 
 use crate::{
     buffer::Buffer,

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -44,7 +44,10 @@ pub use self::paragraph::{Paragraph, Wrap};
 pub use self::sparkline::{RenderDirection, Sparkline};
 pub use self::table::{Cell, Row, Table, TableState};
 pub use self::tabs::Tabs;
-pub use self::widget_list::{WidgetList, WidgetListState};
+pub use self::widget_list::{
+    widget_list_item::{WidgetListItem, WidgetListItem3, WidgetListItem4, WidgetListItem5},
+    WidgetList, WidgetListState,
+};
 
 use crate::{
     buffer::Buffer,

--- a/src/widgets/widget_list/layout.rs
+++ b/src/widgets/widget_list/layout.rs
@@ -1,0 +1,114 @@
+use crate::{
+    layout::{Constraint, Rect},
+    widgets::SizeHint,
+};
+
+pub struct Layout {
+    pub offset: usize,
+    pub item_areas: Vec<Rect>,
+}
+
+impl Layout {
+    pub fn new(
+        area: &Rect,
+        spacing: u16,
+        items: &[impl SizeHint],
+        selected: &Option<usize>,
+        offset: usize,
+        item_lengths: &[Option<Constraint>],
+    ) -> Self {
+        let mut start = offset.min(items.len().saturating_sub(1));
+        if let Some(selected) = selected {
+            start = start.min(*selected);
+        }
+
+        let iter = items
+            .iter()
+            .enumerate()
+            .map(|(index, item)| {
+                (
+                    item,
+                    item_lengths.get(index).map_or(&None::<Constraint>, |e| e),
+                )
+            })
+            .skip(start);
+
+        let mut layout = create_layout(iter, *area, spacing);
+        let end = start + layout.item_areas.len();
+        layout.offset = start;
+
+        if let Some(selected) = selected {
+            if *selected > 0 && *selected >= end.saturating_sub(1) {
+                layout = create_layout(
+                    items
+                        .iter()
+                        .enumerate()
+                        .map(|(index, item)| {
+                            (
+                                item,
+                                item_lengths.get(index).map_or(&None::<Constraint>, |e| e),
+                            )
+                        })
+                        .take(selected + 1)
+                        .rev(),
+                    *area,
+                    spacing,
+                );
+                layout.offset = selected + 1 - layout.item_areas.len();
+                layout.item_areas.reverse();
+
+                let first_bottom = layout.item_areas.first().map(|e| e.bottom());
+                for item in layout.item_areas.iter_mut() {
+                    item.y = first_bottom.unwrap() - item.bottom() + area.y;
+                }
+            }
+        }
+
+        layout
+    }
+}
+
+fn get_item_height(item: &impl SizeHint, constraint: &Option<Constraint>, area: &Rect) -> u16 {
+    match constraint {
+        Some(constraint) => {
+            let area = Rect {
+                height: constraint.apply(area.height).min(area.height),
+                ..*area
+            };
+            let height = item.size_hint(&area).height;
+            constraint.apply(height).max(height)
+        }
+
+        None => item.size_hint(area).height,
+    }
+}
+
+fn create_layout<'b>(
+    iter: impl Iterator<Item = (&'b (impl SizeHint + 'b), &'b Option<Constraint>)>,
+    mut area: Rect,
+    spacing: u16,
+) -> Layout {
+    let mut layout = Layout {
+        offset: 0,
+        item_areas: vec![],
+    };
+
+    for (item, constraint) in iter {
+        let item_height = get_item_height(item, constraint, &area);
+        if item_height > area.height {
+            break;
+        }
+        layout.item_areas.push(Rect {
+            height: item_height,
+            ..area
+        });
+
+        area.y += item_height + spacing;
+        area.height = area.height.saturating_sub(item_height + spacing);
+        if area.height == 0 {
+            break;
+        }
+    }
+
+    layout
+}

--- a/src/widgets/widget_list/layout.rs
+++ b/src/widgets/widget_list/layout.rs
@@ -22,26 +22,24 @@ impl Layout {
             start = start.min(*selected);
         }
 
-        let iter = items
-            .iter()
-            .enumerate()
-            .map(|(index, item)| {
-                (
-                    item,
-                    item_lengths.get(index).map_or(&None::<Constraint>, |e| e),
-                )
-            })
-            .skip(start);
+        let iter = items.iter().skip(start).enumerate().map(|(index, item)| {
+            (
+                item,
+                item_lengths.get(index).map_or(&None::<Constraint>, |e| e),
+            )
+        });
 
         let mut layout = create_layout(iter, *area, spacing);
         let end = start + layout.item_areas.len();
         layout.offset = start;
 
         if let Some(selected) = selected {
-            if *selected > 0 && *selected >= end.saturating_sub(1) {
+            let selected = (items.len() - 1).min(*selected);
+            if selected > 0 && selected >= end.saturating_sub(1) {
                 layout = create_layout(
                     items
                         .iter()
+                        .take(selected + 1)
                         .enumerate()
                         .map(|(index, item)| {
                             (
@@ -49,7 +47,6 @@ impl Layout {
                                 item_lengths.get(index).map_or(&None::<Constraint>, |e| e),
                             )
                         })
-                        .take(selected + 1)
                         .rev(),
                     *area,
                     spacing,

--- a/src/widgets/widget_list/mod.rs
+++ b/src/widgets/widget_list/mod.rs
@@ -1,0 +1,192 @@
+use crate::{
+    buffer::Buffer,
+    layout::{Constraint, Corner, Rect},
+    style::Style,
+    widgets::{Block, StatefulWidget, Widget},
+};
+
+use self::layout::Layout;
+
+use super::SizeHint;
+
+mod layout;
+
+#[derive(Debug, Clone, Default)]
+pub struct WidgetListState {
+    offset: usize,
+    selected: Option<usize>,
+}
+
+impl WidgetListState {
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    pub fn offset_mut(&mut self) -> &mut usize {
+        &mut self.offset
+    }
+
+    pub fn with_selected(mut self, selected: Option<usize>) -> Self {
+        self.selected = selected;
+        self
+    }
+
+    pub fn with_offset(mut self, offset: usize) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    pub fn selected(&self) -> Option<usize> {
+        self.selected
+    }
+
+    pub fn select(&mut self, index: Option<usize>) {
+        self.selected = index;
+        if index.is_none() {
+            self.offset = 0;
+        }
+    }
+}
+
+/// A widget to display several items among which one can be selected (optional)
+///
+/// # Examples
+///
+/// ```
+/// # use ratatui::widgets::{Block, Borders, WidgetList, Paragraph};
+/// # use ratatui::style::{Style, Color};
+/// let items = [
+///     Paragraph::new("Item 1\ndescription"),
+///     Paragraph::new("Item 2\ndescription"),
+///     Paragraph::new("Item 3\ndescription"),
+/// ];
+/// WidgetList::new(items)
+///     .block(Block::default().title("List").borders(Borders::ALL))
+///     .style(Style::default().fg(Color::White));
+/// ```
+#[derive(Debug, Clone)]
+pub struct WidgetList<'a, E: Widget + SizeHint> {
+    block: Option<Block<'a>>,
+    items: Vec<E>,
+    style: Style,
+    start_corner: Corner,
+    /// Padding between each item
+    spacing: u16,
+    item_heights: Vec<Option<Constraint>>,
+}
+
+impl<'a, E> WidgetList<'a, E>
+where
+    E: Widget + SizeHint,
+{
+    pub fn new<T>(items: T) -> WidgetList<'a, E>
+    where
+        T: Into<Vec<E>>,
+        E: Widget + SizeHint,
+    {
+        WidgetList {
+            block: None,
+            style: Style::default(),
+            items: items.into(),
+            start_corner: Corner::TopLeft,
+            spacing: 0,
+            item_heights: vec![],
+        }
+    }
+
+    pub fn block(mut self, block: Block<'a>) -> WidgetList<'a, E> {
+        self.block = Some(block);
+        self
+    }
+
+    pub fn style(mut self, style: Style) -> WidgetList<'a, E> {
+        self.style = style;
+        self
+    }
+
+    /// indicate an individual constraint to list items.
+    /// if the given vector is smaller than the item count, then the missing constraint will be set to None
+    pub fn item_heights(mut self, item_heights: Vec<Option<Constraint>>) -> WidgetList<'a, E> {
+        self.item_heights = item_heights;
+        self
+    }
+
+    pub fn start_corner(mut self, corner: Corner) -> WidgetList<'a, E> {
+        self.start_corner = corner;
+        self
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// indicates the amount of spacing between each item in the list
+    pub fn spacing(mut self, spacing: u16) -> WidgetList<'a, E> {
+        self.spacing = spacing;
+        self
+    }
+}
+
+impl<'a, E> StatefulWidget for WidgetList<'a, E>
+where
+    E: Widget + SizeHint,
+{
+    type State = WidgetListState;
+
+    fn render(mut self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        buf.set_style(area, self.style);
+        let list_area = match self.block.take() {
+            Some(b) => {
+                let inner_area = b.inner(area);
+                b.render(area, buf);
+                inner_area
+            }
+            None => area,
+        };
+
+        if list_area.width < 1 || list_area.height < 1 {
+            return;
+        }
+
+        if self.items.is_empty() {
+            return;
+        }
+
+        let layout = Layout::new(
+            &list_area,
+            self.spacing,
+            &self.items,
+            &state.selected,
+            state.offset,
+            &self.item_heights,
+        );
+
+        state.offset = layout.offset;
+
+        for (item, mut area) in self
+            .items
+            .into_iter()
+            .skip(state.offset)
+            .zip(layout.item_areas)
+        {
+            if let Corner::BottomLeft = self.start_corner {
+                area.y = list_area.bottom() - area.bottom() + list_area.y;
+            }
+            item.render(area, buf);
+        }
+    }
+}
+
+impl<'a, E> Widget for WidgetList<'a, E>
+where
+    E: Widget + SizeHint,
+{
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let mut state = WidgetListState::default();
+        StatefulWidget::render(self, area, buf, &mut state);
+    }
+}

--- a/src/widgets/widget_list/mod.rs
+++ b/src/widgets/widget_list/mod.rs
@@ -10,6 +10,7 @@ use self::layout::Layout;
 use super::SizeHint;
 
 mod layout;
+pub mod widget_list_item;
 
 #[derive(Debug, Clone, Default)]
 pub struct WidgetListState {

--- a/src/widgets/widget_list/stateful_widget_list_item.rs
+++ b/src/widgets/widget_list/stateful_widget_list_item.rs
@@ -1,0 +1,43 @@
+use crate::{
+    buffer::Buffer,
+    layout::{Rect, Size},
+    widgets::{SizeHint, StatefulWidget},
+};
+
+pub enum WidgetListItem<'a, S, T, U>
+where
+    T: StatefulWidget + SizeHint,
+    U: StatefulWidget + SizeHint,
+{
+    One(T, &'a S),
+    Two(U, &'a S),
+}
+
+
+impl<S, T, U> SizeHint for WidgetListItem<S, T, U>
+where
+    T: StatefulWidget + SizeHint,
+    U: StatefulWidget + SizeHint,
+{
+    fn size_hint(&self, area: &Rect) -> Size {
+        match self {
+            WidgetListItem::One(e) => e.size_hint(area),
+            WidgetListItem::Two(e) => e.size_hint(area),
+        }
+    }
+}
+
+impl<S, T, U> StatefulWidget for WidgetListItem<S, T, U>
+where
+    T: StatefulWidget + SizeHint,
+    U: StatefulWidget + SizeHint,
+{
+    type State = S;
+
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        match self {
+            WidgetListItem::One(e, s) => e.render(area, buf, &mut s),
+            WidgetListItem::Two(e, s) => e.render(area, buf, &mut s),
+        }
+    }
+}

--- a/src/widgets/widget_list/widget_list_item.rs
+++ b/src/widgets/widget_list/widget_list_item.rs
@@ -1,0 +1,181 @@
+use crate::{
+    buffer::Buffer,
+    layout::{Rect, Size},
+    widgets::{SizeHint, Widget},
+};
+
+pub enum WidgetListItem<T, U>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+{
+    One(T),
+    Two(U),
+}
+
+pub enum WidgetListItem3<T, U, W>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+    W: Widget + SizeHint,
+{
+    One(T),
+    Two(U),
+    Three(W),
+}
+
+pub enum WidgetListItem4<T, U, W, X>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+    W: Widget + SizeHint,
+    X: Widget + SizeHint,
+{
+    One(T),
+    Two(U),
+    Three(W),
+    Four(X),
+}
+
+pub enum WidgetListItem5<T, U, W, X, Z>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+    W: Widget + SizeHint,
+    X: Widget + SizeHint,
+    Z: Widget + SizeHint,
+{
+    One(T),
+    Two(U),
+    Three(W),
+    Four(X),
+    Five(Z),
+}
+
+impl<T, U> SizeHint for WidgetListItem<T, U>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+{
+    fn size_hint(&self, area: &Rect) -> Size {
+        match self {
+            WidgetListItem::One(e) => e.size_hint(area),
+            WidgetListItem::Two(e) => e.size_hint(area),
+        }
+    }
+}
+
+impl<T, U> Widget for WidgetListItem<T, U>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+{
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        match self {
+            WidgetListItem::One(e) => e.render(area, buf),
+            WidgetListItem::Two(e) => e.render(area, buf),
+        }
+    }
+}
+
+impl<T, U, W> SizeHint for WidgetListItem3<T, U, W>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+    W: Widget + SizeHint,
+{
+    fn size_hint(&self, area: &Rect) -> Size {
+        match self {
+            WidgetListItem3::One(e) => e.size_hint(area),
+            WidgetListItem3::Two(e) => e.size_hint(area),
+            WidgetListItem3::Three(e) => e.size_hint(area),
+        }
+    }
+}
+
+impl<T, U, W> Widget for WidgetListItem3<T, U, W>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+    W: Widget + SizeHint,
+{
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        match self {
+            WidgetListItem3::One(e) => e.render(area, buf),
+            WidgetListItem3::Two(e) => e.render(area, buf),
+            WidgetListItem3::Three(e) => e.render(area, buf),
+        }
+    }
+}
+
+impl<T, U, W, X> SizeHint for WidgetListItem4<T, U, W, X>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+    W: Widget + SizeHint,
+    X: Widget + SizeHint,
+{
+    fn size_hint(&self, area: &Rect) -> Size {
+        match self {
+            WidgetListItem4::One(e) => e.size_hint(area),
+            WidgetListItem4::Two(e) => e.size_hint(area),
+            WidgetListItem4::Three(e) => e.size_hint(area),
+            WidgetListItem4::Four(e) => e.size_hint(area),
+        }
+    }
+}
+
+impl<T, U, W, X> Widget for WidgetListItem4<T, U, W, X>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+    W: Widget + SizeHint,
+    X: Widget + SizeHint,
+{
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        match self {
+            WidgetListItem4::One(e) => e.render(area, buf),
+            WidgetListItem4::Two(e) => e.render(area, buf),
+            WidgetListItem4::Three(e) => e.render(area, buf),
+            WidgetListItem4::Four(e) => e.render(area, buf),
+        }
+    }
+}
+
+impl<T, U, W, X, Z> SizeHint for WidgetListItem5<T, U, W, X, Z>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+    W: Widget + SizeHint,
+    X: Widget + SizeHint,
+    Z: Widget + SizeHint,
+{
+    fn size_hint(&self, area: &Rect) -> Size {
+        match self {
+            WidgetListItem5::One(e) => e.size_hint(area),
+            WidgetListItem5::Two(e) => e.size_hint(area),
+            WidgetListItem5::Three(e) => e.size_hint(area),
+            WidgetListItem5::Four(e) => e.size_hint(area),
+            WidgetListItem5::Five(e) => e.size_hint(area),
+        }
+    }
+}
+
+impl<T, U, W, X, Z> Widget for WidgetListItem5<T, U, W, X, Z>
+where
+    T: Widget + SizeHint,
+    U: Widget + SizeHint,
+    W: Widget + SizeHint,
+    X: Widget + SizeHint,
+    Z: Widget + SizeHint,
+{
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        match self {
+            WidgetListItem5::One(e) => e.render(area, buf),
+            WidgetListItem5::Two(e) => e.render(area, buf),
+            WidgetListItem5::Three(e) => e.render(area, buf),
+            WidgetListItem5::Four(e) => e.render(area, buf),
+            WidgetListItem5::Five(e) => e.render(area, buf),
+        }
+    }
+}


### PR DESCRIPTION
#132

add SizeHint trait, Size Struct so that the widgets can report the preferred size

run `cargo run --example widget_list` to test (try to make terminal width small enough, so the text get wrapped)

[![asciicast](https://asciinema.org/a/fRoLGyuMFdjNUMyg6XdI95u0f.svg)](https://asciinema.org/a/fRoLGyuMFdjNUMyg6XdI95u0f)