### PR TITLE
feat(test): expose test buffer

### DIFF
--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -3,7 +3,10 @@ use crate::{
     buffer::{Buffer, Cell},
     layout::Rect,
 };
-use std::{fmt::Write, io};
+use std::{
+    fmt::{Display, Write},
+    io,
+};
 use unicode_width::UnicodeWidthStr;
 
 /// A backend used for the integration tests.
@@ -102,6 +105,12 @@ impl TestBackend {
             .join("\n");
         debug_info.push_str(&nice_diff);
         panic!("{}", debug_info);
+    }
+}
+
+impl Display for TestBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", buffer_view(&self.buffer))
     }
 }
 


### PR DESCRIPTION
Allow a way to expose the buffer of the `TestBackend`, to easier support different testing methodologies.