### PR TITLE
test(buffer): add `assert_buffer_eq!` and Debug implementation

### DIFF
--- a/src/widgets/sparkline.rs
+++ b/src/widgets/sparkline.rs
@@ -153,9 +153,8 @@ impl<'a> Widget for Sparkline<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::buffer::Cell;
-
     use super::*;
+    use crate::{assert_buffer_eq, buffer::Cell};
 
     // Helper function to render a sparkline to a buffer with a given width
     // filled with x symbols to make it easier to assert on the result
@@ -172,21 +171,21 @@ mod tests {
     fn it_does_not_panic_if_max_is_zero() {
         let widget = Sparkline::default().data(&[0, 0, 0]);
         let buffer = render(widget, 6);
-        assert_eq!(buffer, Buffer::with_lines(vec!["   xxx"]));
+        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["   xxx"]));
     }
 
     #[test]
     fn it_does_not_panic_if_max_is_set_to_zero() {
         let widget = Sparkline::default().data(&[0, 1, 2]).max(0);
         let buffer = render(widget, 6);
-        assert_eq!(buffer, Buffer::with_lines(vec!["   xxx"]));
+        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["   xxx"]));
     }
 
     #[test]
     fn it_draws() {
         let widget = Sparkline::default().data(&[0, 1, 2, 3, 4, 5, 6, 7, 8]);
         let buffer = render(widget, 12);
-        assert_eq!(buffer, Buffer::with_lines(vec![" ▁▂▃▄▅▆▇█xxx"]));
+        assert_buffer_eq!(buffer, Buffer::with_lines(vec![" ▁▂▃▄▅▆▇█xxx"]));
     }
 
     #[test]
@@ -195,7 +194,7 @@ mod tests {
             .data(&[0, 1, 2, 3, 4, 5, 6, 7, 8])
             .direction(RenderDirection::LeftToRight);
         let buffer = render(widget, 12);
-        assert_eq!(buffer, Buffer::with_lines(vec![" ▁▂▃▄▅▆▇█xxx"]));
+        assert_buffer_eq!(buffer, Buffer::with_lines(vec![" ▁▂▃▄▅▆▇█xxx"]));
     }
 
     #[test]
@@ -204,6 +203,6 @@ mod tests {
             .data(&[0, 1, 2, 3, 4, 5, 6, 7, 8])
             .direction(RenderDirection::RightToLeft);
         let buffer = render(widget, 12);
-        assert_eq!(buffer, Buffer::with_lines(vec!["xxx█▇▆▅▄▃▂▁ "]));
+        assert_buffer_eq!(buffer, Buffer::with_lines(vec!["xxx█▇▆▅▄▃▂▁ "]));
     }
 }


### PR DESCRIPTION
This makes it easier to write unit tests with fast feedback against buffers. The implementation is copied from TestBackend (with some refactoring). Also adds a unit test for buffer_set_string_multi_width_overwrite which was missing from the buffer tests

Output (from some intentionally failing tests):
```
failures:

---- buffer::tests::buffer_set_string stdout ----
thread 'buffer::tests::buffer_set_string' panicked at 'buffer contents not equal
  expected:
  "baa  "

  actual:
  "aaa  "

  diff:
  0: at (0, 0)
  expected: Cell { symbol: "b", fg: Reset, bg: Reset, modifier: (empty) }
  actual:   Cell { symbol: "a", fg: Reset, bg: Reset, modifier: (empty) }', src/buffer.rs:604:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- buffer::tests::buffer_set_string_zero_width stdout ----
thread 'buffer::tests::buffer_set_string_zero_width' panicked at 'buffer areas not equal
  expected:  Rect { x: 0, y: 0, width: 2, height: 1 }
  actual:    Rect { x: 0, y: 0, width: 1, height: 1 }', src/buffer.rs:642:9

---- buffer::tests::buffer_set_string_multi_width_overwrite stdout ----
thread 'buffer::tests::buffer_set_string_multi_width_overwrite' panicked at 'buffer contents not equal
  expected:
  "称号b" Hidden by multi-width symbols: [(1, " "), (3, " ")]

  actual:
  "称号a" Hidden by multi-width symbols: [(1, " "), (3, " ")]

  diff:
  0: at (4, 0)
  expected: Cell { symbol: "b", fg: Reset, bg: Reset, modifier: (empty) }
  actual:   Cell { symbol: "a", fg: Reset, bg: Reset, modifier: (empty) }', src/buffer.rs:631:9
```