### PR TITLE
ci: add ci, build, and revert to allowed commit types

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -55,19 +55,21 @@ commit_preprocessors = [
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-    { message = "^feat", group = "<!-- 0 -->Features"},
-    { message = "^fix", group = "<!-- 1 -->Bug Fixes"},
-    { message = "^Fix", group = "<!-- 1 -->Bug Fixes"},
-    { message = "^doc", group = "<!-- 3 -->Documentation"},
-    { message = "^perf", group = "<!-- 4 -->Performance"},
-    { message = "^refactor", group = "<!-- 2 -->Refactor"},
-    { message = "^style", group = "<!-- 5 -->Styling"},
-    { message = "^test", group = "<!-- 6 -->Testing"},
+    { message = "^feat", group = "<!-- 00 -->Features"},
+    { message = "^[fF]ix", group = "<!-- 01 -->Bug Fixes"},
+    { message = "^refactor", group = "<!-- 02 -->Refactor"},
+    { message = "^doc", group = "<!-- 03 -->Documentation"},
+    { message = "^perf", group = "<!-- 04 -->Performance"},
+    { message = "^style", group = "<!-- 05 -->Styling"},
+    { message = "^test", group = "<!-- 06 -->Testing"},
     { message = "^chore\\(release\\): prepare for", skip = true},
     { message = "^chore\\(pr\\)", skip = true},
     { message = "^chore\\(pull\\)", skip = true},
-    { message = "^chore", group = "<!-- 7 -->Miscellaneous Tasks"},
-    { body = ".*security", group = "<!-- 8 -->Security"},
+    { message = "^chore", group = "<!-- 07 -->Miscellaneous Tasks"},
+    { body = ".*security", group = "<!-- 08 -->Security"},
+    { message = "^build", group = "<!-- 09 -->Build"},
+    { message = "^ci", group = "<!-- 10 -->Continuous Integration"},
+    { message = "^revert", group = "<!-- 11 -->Reverted Commits"},
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false

--- a/committed.toml
+++ b/committed.toml
@@ -14,3 +14,5 @@ subject_not_punctuated = true
 line_length = 0
 # disable subject length
 subject_length = 0
+# default allowed_types [ "chore", "docs", "feat", "fix", "perf", "refactor", "style", "test" ]
+allowed_types = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test" ]


### PR DESCRIPTION
This is the same list as https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional\#rules

I find myself often reaching for ci: and build: and realizing that they aren't configured in this repo, and having to rewrite to chore: to make the linter happy.