### PR TITLE
style(format): use variable inlining in format! macros

### DIFF
--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -36,12 +36,7 @@ fn buffer_view(buffer: &Buffer) -> String {
         }
         view.push('"');
         if !overwritten.is_empty() {
-            write!(
-                &mut view,
-                " Hidden by multi-width symbols: {:?}",
-                overwritten
-            )
-            .unwrap();
+            write!(&mut view, " Hidden by multi-width symbols: {overwritten:?}").unwrap();
         }
         view.push('\n');
     }
@@ -96,10 +91,7 @@ impl TestBackend {
             .enumerate()
             .map(|(i, (x, y, cell))| {
                 let expected_cell = expected.get(*x, *y);
-                format!(
-                    "{}: at ({}, {}) expected {:?} got {:?}",
-                    i, x, y, expected_cell, cell
-                )
+                format!("{i}: at ({x}, {y}) expected {expected_cell:?} got {cell:?}")
             })
             .collect::<Vec<String>>()
             .join("\n");

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -545,8 +545,7 @@ impl Debug for Buffer {
             }
             if !overwritten.is_empty() {
                 f.write_fmt(format_args!(
-                    "// hidden by multi-width symbols: {:?}",
-                    overwritten
+                    "// hidden by multi-width symbols: {overwritten:?}"
                 ))?;
             }
             f.write_str("\",\n")?;
@@ -587,7 +586,7 @@ mod tests {
                 .add_modifier(Modifier::BOLD),
         );
         assert_eq!(
-            format!("{:?}", buf),
+            format!("{buf:?}"),
             indoc::indoc!(
                 "
                 Buffer {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -149,7 +149,7 @@ where
         // Attempt to restore the cursor state
         if self.hidden_cursor {
             if let Err(err) = self.show_cursor() {
-                eprintln!("Failed to show the cursor: {}", err);
+                eprintln!("Failed to show the cursor: {err}");
             }
         }
     }

--- a/src/widgets/barchart.rs
+++ b/src/widgets/barchart.rs
@@ -75,7 +75,7 @@ impl<'a> BarChart<'a> {
         self.data = data;
         self.values = Vec::with_capacity(self.data.len());
         for &(_, v) in self.data {
-            self.values.push(format!("{}", v));
+            self.values.push(format!("{v}"));
         }
         self
     }

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -645,7 +645,7 @@ mod tests {
         for case in &cases {
             let datasets = (0..10)
                 .map(|i| {
-                    let name = format!("Dataset #{}", i);
+                    let name = format!("Dataset #{i}");
                     Dataset::default().name(name).data(&data)
                 })
                 .collect::<Vec<_>>();

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -111,8 +111,7 @@ impl<'a> Widget for Gauge<'a> {
         // label is put at the center of the gauge_area
         let label = {
             let pct = f64::round(self.ratio * 100.0);
-            self.label
-                .unwrap_or_else(|| Span::from(format!("{}%", pct)))
+            self.label.unwrap_or_else(|| Span::from(format!("{pct}%")))
         };
         let clamped_label_width = gauge_area.width.min(label.width() as u16);
         let label_col = gauge_area.left() + (gauge_area.width - clamped_label_width) / 2;


### PR DESCRIPTION
Simply makes the suggested changes from clippy for inline variables in string templates.

Can be closed if undesired but maybe worth to be discussed.