### PR TITLE
build: bump MSRV to 1.65.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: ["1.59.0", "stable"]
+        rust: ["1.65.0", "stable"]
         include:
           - os: ubuntu-latest
             triple: x86_64-unknown-linux-musl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 exclude = ["assets/*", ".github", "Makefile.toml", "CONTRIBUTING.md", "*.log", "tags"]
 autoexamples = true
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.65.0"
 
 [badges]
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ you may rely on the previously cited libraries to achieve such features.
 
 ## Rust version requirements
 
-Since version 0.17.0, `ratatui` requires **rustc version 1.59.0 or greater**.
+Since version 0.21.0, `ratatui` requires **rustc version 1.65.0 or greater**.
 
 # Documentation
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,7 +16,7 @@ pub use self::crossterm::CrosstermBackend;
 mod test;
 pub use self::test::TestBackend;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClearType {
     All,
     AfterCursor,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -6,14 +6,14 @@ use crate::{
 };
 use std::io;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Viewport {
     Fullscreen,
     Inline(u16),
     Fixed(Rect),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// Options to pass to [`Terminal::with_options`]
 pub struct TerminalOptions {
     /// Viewport used to draw to the terminal

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -313,17 +313,8 @@ impl<'a> Widget for Block<'a> {
 
         // Title
         if let Some(title) = self.title {
-            let left_border_dx = if self.borders.intersects(Borders::LEFT) {
-                1
-            } else {
-                0
-            };
-
-            let right_border_dx = if self.borders.intersects(Borders::RIGHT) {
-                1
-            } else {
-                0
-            };
+            let left_border_dx = self.borders.intersects(Borders::LEFT) as u16;
+            let right_border_dx = self.borders.intersects(Borders::RIGHT) as u16;
 
             let title_area_width = area
                 .width

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -366,7 +366,7 @@ impl<'a> Chart<'a> {
             let width_left_of_y_axis = match self.x_axis.labels_alignment {
                 Alignment::Left => {
                     // The last character of the label should be below the Y-Axis when it exists, not on its left
-                    let y_axis_offset = if has_y_axis { 1 } else { 0 };
+                    let y_axis_offset = has_y_axis as u16;
                     first_label_width.saturating_sub(y_axis_offset)
                 }
                 Alignment::Center => first_label_width / 2,


### PR DESCRIPTION
The latest version of the time crate requires Rust 1.65.0

```
cargo +1.64.0-x86_64-apple-darwin test --no-default-features \
  --features serde,crossterm,all-widgets --lib --tests --examples
error: package `time v0.3.21` cannot be built because it requires rustc
1.65.0 or newer, while the currently active rustc version is 1.64.0
```

The calendar widget added a dependency on time v0.3.11 (though a quick check suggests that 0.3.9 compiles, I'm unsure if the later bug fixes are notable for ratatui. Regardless, the dependency requirement is satisfied by any version later than 0.3.11. Later versions require rust 1.65.0, so our MSRV is 1.65.0.

I don't think there's an obvious way to only specify a MSRV for a specific set of features (i.e. 1.59 if you're not using termwiz/calendar), though perhaps we leave this as 1.59, and create a specific 1.59 test in the ci that doesn't test calendar and termwiz. I'm not certain I know why we'd do that (ping @rhysd for input on what the reason for supporting 1.59 was in https://github.com/tui-rs-revival/ratatui/pull/85

I'm a rust noob, so my experience with the impact of choosing an MSRV is limited. I've seen a few libraries that state a policy of supporting stable minus 2 version, which seems reasonable on the face of it. If we took that approach, we'd go with 1.67 which was released Jan (26 2023). But we only "need" to go to 1.65 for now.