### PR TITLE
refactor(text): rename `Spans` to `Line`

### DIFF
--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -4,7 +4,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     symbols,
-    text::{Span, Line},
+    text::{Line, Span},
     widgets::canvas::{Canvas, Circle, Line as ShapeLine, Map, MapResolution, Rectangle},
     widgets::{
         Axis, BarChart, Block, Borders, Cell, Chart, Dataset, Gauge, LineGauge, List, ListItem,

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -4,8 +4,8 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     symbols,
-    text::{Span, Spans},
-    widgets::canvas::{Canvas, Circle, Line, Map, MapResolution, Rectangle},
+    text::{Span, Line},
+    widgets::canvas::{Canvas, Circle, Line as ShapeLine, Map, MapResolution, Rectangle},
     widgets::{
         Axis, BarChart, Block, Borders, Cell, Chart, Dataset, Gauge, LineGauge, List, ListItem,
         Paragraph, Row, Sparkline, Table, Tabs, Wrap,
@@ -21,7 +21,7 @@ pub fn draw<B: Backend>(f: &mut Frame<B>, app: &mut App) {
         .tabs
         .titles
         .iter()
-        .map(|t| Spans::from(Span::styled(*t, Style::default().fg(Color::Green))))
+        .map(|t| Line::from(Span::styled(*t, Style::default().fg(Color::Green))))
         .collect();
     let tabs = Tabs::new(titles)
         .block(Block::default().borders(Borders::ALL).title(app.title))
@@ -137,7 +137,7 @@ where
                 .tasks
                 .items
                 .iter()
-                .map(|i| ListItem::new(vec![Spans::from(Span::raw(*i))]))
+                .map(|i| ListItem::new(vec![Line::from(Span::raw(*i))]))
                 .collect();
             let tasks = List::new(tasks)
                 .block(Block::default().borders(Borders::ALL).title("List"))
@@ -161,7 +161,7 @@ where
                         "WARNING" => warning_style,
                         _ => info_style,
                     };
-                    let content = vec![Spans::from(vec![
+                    let content = vec![Line::from(vec![
                         Span::styled(format!("{:<9}", level), s),
                         Span::raw(evt),
                     ])];
@@ -261,9 +261,9 @@ where
     B: Backend,
 {
     let text = vec![
-        Spans::from("This is a paragraph with several lines. You can change style your text the way you want"),
-        Spans::from(""),
-        Spans::from(vec![
+        Line::from("This is a paragraph with several lines. You can change style your text the way you want"),
+        Line::from(""),
+        Line::from(vec![
             Span::from("For example: "),
             Span::styled("under", Style::default().fg(Color::Red)),
             Span::raw(" "),
@@ -272,7 +272,7 @@ where
             Span::styled("rainbow", Style::default().fg(Color::Blue)),
             Span::raw("."),
         ]),
-        Spans::from(vec![
+        Line::from(vec![
             Span::raw("Oh and if you didn't "),
             Span::styled("notice", Style::default().add_modifier(Modifier::ITALIC)),
             Span::raw(" you can "),
@@ -283,7 +283,7 @@ where
             Span::styled("text", Style::default().add_modifier(Modifier::UNDERLINED)),
             Span::raw(".")
         ]),
-        Spans::from(
+        Line::from(
             "One more thing is that it should display unicode characters: 10€"
         ),
     ];
@@ -354,7 +354,7 @@ where
             });
             for (i, s1) in app.servers.iter().enumerate() {
                 for s2 in &app.servers[i + 1..] {
-                    ctx.draw(&Line {
+                    ctx.draw(&ShapeLine {
                         x1: s1.coords.1,
                         y1: s1.coords.0,
                         y2: s2.coords.0,

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -4,7 +4,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     symbols,
-    text::{Span, Spans},
+    text::{Span, Line},
     widgets::{Block, Gauge, LineGauge, List, ListItem, Paragraph, Widget},
     Frame, Terminal, TerminalOptions, Viewport,
 };
@@ -193,7 +193,7 @@ fn run_app<B: Backend>(
             Event::DownloadDone(worker_id, download_id) => {
                 let download = downloads.in_progress.remove(&worker_id).unwrap();
                 terminal.insert_before(1, |buf| {
-                    Paragraph::new(Spans::from(vec![
+                    Paragraph::new(Line::from(vec![
                         Span::from("Finished "),
                         Span::styled(
                             format!("download {}", download_id),
@@ -254,7 +254,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, downloads: &Downloads) {
         .in_progress
         .values()
         .map(|download| {
-            ListItem::new(Spans::from(vec![
+            ListItem::new(Line::from(vec![
                 Span::raw(symbols::DOT),
                 Span::styled(
                     format!(" download {:>2}", download.id),

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -4,7 +4,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     symbols,
-    text::{Span, Line},
+    text::{Line, Span},
     widgets::{Block, Gauge, LineGauge, List, ListItem, Paragraph, Widget},
     Frame, Terminal, TerminalOptions, Viewport,
 };

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -7,7 +7,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Corner, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Span, Line},
+    text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState},
     Frame, Terminal,
 };

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -7,7 +7,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Corner, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Span, Spans},
+    text::{Span, Line},
     widgets::{Block, Borders, List, ListItem, ListState},
     Frame, Terminal,
 };
@@ -217,9 +217,9 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App) {
         .items
         .iter()
         .map(|i| {
-            let mut lines = vec![Spans::from(i.0)];
+            let mut lines = vec![Line::from(i.0)];
             for _ in 0..i.1 {
-                lines.push(Spans::from(Span::styled(
+                lines.push(Line::from(Span::styled(
                     "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                     Style::default().add_modifier(Modifier::ITALIC),
                 )));
@@ -257,7 +257,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App) {
                 _ => Style::default(),
             };
             // Add a example datetime and apply proper spacing between them
-            let header = Spans::from(vec![
+            let header = Line::from(vec![
                 Span::styled(format!("{:<9}", level), s),
                 Span::raw(" "),
                 Span::styled(
@@ -266,7 +266,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App) {
                 ),
             ]);
             // The event gets its own line
-            let log = Spans::from(vec![Span::raw(event)]);
+            let log = Line::from(vec![Span::raw(event)]);
 
             // Here several things happen:
             // 1. Add a `---` spacing line above the final list entry
@@ -274,9 +274,9 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App) {
             // 3. Add a spacer line
             // 4. Add the actual event
             ListItem::new(vec![
-                Spans::from("-".repeat(chunks[1].width as usize)),
+                Line::from("-".repeat(chunks[1].width as usize)),
                 header,
-                Spans::from(""),
+                Line::from(""),
                 log,
             ])
         })

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -26,7 +26,7 @@ use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
 
 use ratatui::backend::{Backend, CrosstermBackend};
 use ratatui::layout::Alignment;
-use ratatui::text::Spans;
+use ratatui::text::Line;
 use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::{Frame, Terminal};
 
@@ -113,23 +113,23 @@ fn run_tui<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> io::Result<
 fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
     let text = vec![
         if app.hook_enabled {
-            Spans::from("HOOK IS CURRENTLY **ENABLED**")
+            Line::from("HOOK IS CURRENTLY **ENABLED**")
         } else {
-            Spans::from("HOOK IS CURRENTLY **DISABLED**")
+            Line::from("HOOK IS CURRENTLY **DISABLED**")
         },
-        Spans::from(""),
-        Spans::from("press `p` to panic"),
-        Spans::from("press `e` to enable the terminal-resetting panic hook"),
-        Spans::from("press any other key to quit without panic"),
-        Spans::from(""),
-        Spans::from("when you panic without the chained hook,"),
-        Spans::from("you will likely have to reset your terminal afterwards"),
-        Spans::from("with the `reset` command"),
-        Spans::from(""),
-        Spans::from("with the chained panic hook enabled,"),
-        Spans::from("you should see the panic report as you would without ratatui"),
-        Spans::from(""),
-        Spans::from("try first without the panic handler to see the difference"),
+        Line::from(""),
+        Line::from("press `p` to panic"),
+        Line::from("press `e` to enable the terminal-resetting panic hook"),
+        Line::from("press any other key to quit without panic"),
+        Line::from(""),
+        Line::from("when you panic without the chained hook,"),
+        Line::from("you will likely have to reset your terminal afterwards"),
+        Line::from("with the `reset` command"),
+        Line::from(""),
+        Line::from("with the chained panic hook enabled,"),
+        Line::from("you should see the panic report as you would without ratatui"),
+        Line::from(""),
+        Line::from("try first without the panic handler to see the difference"),
     ];
 
     let b = Block::default()

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -7,7 +7,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Alignment, Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Masked, Span, Spans},
+    text::{Masked, Span, Line},
     widgets::{Block, Borders, Paragraph, Wrap},
     Frame, Terminal,
 };
@@ -113,27 +113,27 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
         .split(size);
 
     let text = vec![
-        Spans::from("This is a line "),
-        Spans::from(Span::styled(
+        Line::from("This is a line "),
+        Line::from(Span::styled(
             "This is a line   ",
             Style::default().fg(Color::Red),
         )),
-        Spans::from(Span::styled(
+        Line::from(Span::styled(
             "This is a line",
             Style::default().bg(Color::Blue),
         )),
-        Spans::from(Span::styled(
+        Line::from(Span::styled(
             "This is a longer line",
             Style::default().add_modifier(Modifier::CROSSED_OUT),
         )),
-        Spans::from(Span::styled(&long_line, Style::default().bg(Color::Green))),
-        Spans::from(Span::styled(
+        Line::from(Span::styled(&long_line, Style::default().bg(Color::Green))),
+        Line::from(Span::styled(
             "This is a line",
             Style::default()
                 .fg(Color::Green)
                 .add_modifier(Modifier::ITALIC),
         )),
-        Spans::from(vec![
+        Line::from(vec![
             Span::raw("Masked text: "),
             Span::styled(
                 Masked::new("password", '*'),

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -7,7 +7,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Alignment, Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Masked, Span, Line},
+    text::{Line, Masked, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
     Frame, Terminal,
 };

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -7,7 +7,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Span, Line},
+    text::{Line, Span},
     widgets::{Block, Borders, Tabs},
     Frame, Terminal,
 };

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -7,7 +7,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Span, Spans},
+    text::{Span, Line},
     widgets::{Block, Borders, Tabs},
     Frame, Terminal,
 };
@@ -99,7 +99,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
         .iter()
         .map(|t| {
             let (first, rest) = t.split_at(1);
-            Spans::from(vec![
+            Line::from(vec![
                 Span::styled(first, Style::default().fg(Color::Yellow)),
                 Span::styled(rest, Style::default().fg(Color::Green)),
             ])

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -18,7 +18,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Span, Spans, Text},
+    text::{Span, Line, Text},
     widgets::{Block, Borders, List, ListItem, Paragraph},
     Frame, Terminal,
 };
@@ -150,7 +150,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
             Style::default(),
         ),
     };
-    let mut text = Text::from(Spans::from(msg));
+    let mut text = Text::from(Line::from(msg));
     text.patch_style(style);
     let help_message = Paragraph::new(text);
     f.render_widget(help_message, chunks[0]);
@@ -183,7 +183,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
         .iter()
         .enumerate()
         .map(|(i, m)| {
-            let content = Spans::from(Span::raw(format!("{}: {}", i, m)));
+            let content = Line::from(Span::raw(format!("{}: {}", i, m)));
             ListItem::new(content)
         })
         .collect();

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -18,7 +18,7 @@ use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Span, Line, Text},
+    text::{Line, Span, Text},
     widgets::{Block, Borders, List, ListItem, Paragraph},
     Frame, Terminal,
 };

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -330,6 +330,11 @@ impl Buffer {
         (x, y)
     }
 
+    #[deprecated(since = "0.21.0", note = "`Spans` renamed to `Line`. use set_line instead")]
+    pub fn set_spans(&mut self, x: u16, y: u16, spans: &Line<'_>, width: u16) -> (u16, u16) {
+        self.set_line(x, y, spans, width)
+    }
+
     pub fn set_span(&mut self, x: u16, y: u16, span: &Span<'_>, width: u16) -> (u16, u16) {
         self.set_stringn(x, y, span.content.as_ref(), width as usize, span.style)
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,7 +1,7 @@
 use crate::{
     layout::Rect,
     style::{Color, Modifier, Style},
-    text::{Span, Line},
+    text::{Line, Span},
 };
 use std::{
     cmp::min,
@@ -330,7 +330,10 @@ impl Buffer {
         (x, y)
     }
 
-    #[deprecated(since = "0.21.0", note = "`Spans` renamed to `Line`. use set_line instead")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`Spans` renamed to `Line`. use set_line instead"
+    )]
     pub fn set_spans(&mut self, x: u16, y: u16, spans: &Line<'_>, width: u16) -> (u16, u16) {
         self.set_line(x, y, spans, width)
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,7 +1,7 @@
 use crate::{
     layout::Rect,
     style::{Color, Modifier, Style},
-    text::{Span, Spans},
+    text::{Span, Line},
 };
 use std::{
     cmp::min,
@@ -309,10 +309,10 @@ impl Buffer {
         (x_offset as u16, y)
     }
 
-    pub fn set_spans(&mut self, x: u16, y: u16, spans: &Spans<'_>, width: u16) -> (u16, u16) {
+    pub fn set_line(&mut self, x: u16, y: u16, line: &Line<'_>, width: u16) -> (u16, u16) {
         let mut remaining_width = width;
         let mut x = x;
-        for span in &spans.0 {
+        for span in &line.0 {
             if remaining_width == 0 {
                 break;
             }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -386,14 +386,14 @@ where
     ///
     /// ```rust
     /// # use ratatui::widgets::{Paragraph, Widget};
-    /// # use ratatui::text::{Spans, Span};
+    /// # use ratatui::text::{Line, Span};
     /// # use ratatui::style::{Color, Style};
     /// # use ratatui::{Terminal};
     /// # use ratatui::backend::TestBackend;
     /// # let backend = TestBackend::new(10, 10);
     /// # let mut terminal = Terminal::new(backend).unwrap();
     /// terminal.insert_before(1, |buf| {
-    ///     Paragraph::new(Spans::from(vec![
+    ///     Paragraph::new(Line::from(vec![
     ///         Span::raw("This line will be added "),
     ///         Span::styled("before", Style::default().fg(Color::Blue)),
     ///         Span::raw(" the current viewport")

--- a/src/text.rs
+++ b/src/text.rs
@@ -235,7 +235,10 @@ impl<'a> From<&'a str> for Span<'a> {
 #[derive(Debug, Clone, PartialEq, Default, Eq)]
 pub struct Line<'a>(pub Vec<Span<'a>>);
 
-#[deprecated(since = "0.21.0", note = "`Spans` is renamed to `Line` and will be removed in a future release. Use `Line` instead")]
+#[deprecated(
+    since = "0.21.0",
+    note = "`Spans` is renamed to `Line` and will be removed in a future release. Use `Line` instead"
+)]
 pub type Spans<'a> = Line<'a>;
 
 impl<'a> Line<'a> {
@@ -424,11 +427,7 @@ impl<'a> Text<'a> {
     /// assert_eq!(15, text.width());
     /// ```
     pub fn width(&self) -> usize {
-        self.lines
-            .iter()
-            .map(Line::width)
-            .max()
-            .unwrap_or_default()
+        self.lines.iter().map(Line::width).max().unwrap_or_default()
     }
 
     /// Returns the height.

--- a/src/text.rs
+++ b/src/text.rs
@@ -235,6 +235,9 @@ impl<'a> From<&'a str> for Span<'a> {
 #[derive(Debug, Clone, PartialEq, Default, Eq)]
 pub struct Line<'a>(pub Vec<Span<'a>>);
 
+#[deprecated(since = "0.21.0", note = "`Spans` is renamed to `Line` and will be removed in a future release. Use `Line` instead")]
+pub type Spans<'a> = Line<'a>;
+
 impl<'a> Line<'a> {
     /// Returns the width of the underlying string.
     ///

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -3,7 +3,7 @@ use crate::{
     layout::{Alignment, Rect},
     style::Style,
     symbols::line,
-    text::{Span, Line},
+    text::{Line, Span},
     widgets::{Borders, Widget},
 };
 

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -3,7 +3,7 @@ use crate::{
     layout::{Alignment, Rect},
     style::Style,
     symbols::line,
-    text::{Span, Spans},
+    text::{Span, Line},
     widgets::{Borders, Widget},
 };
 
@@ -99,7 +99,7 @@ impl Padding {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Block<'a> {
     /// Optional title place on the upper left of the block
-    title: Option<Spans<'a>>,
+    title: Option<Line<'a>>,
     /// Title alignment. The default is top left of the block, but one can choose to place
     /// title in the top middle, or top right of the block
     title_alignment: Alignment,
@@ -136,7 +136,7 @@ impl<'a> Default for Block<'a> {
 impl<'a> Block<'a> {
     pub fn title<T>(mut self, title: T) -> Block<'a>
     where
-        T: Into<Spans<'a>>,
+        T: Into<Line<'a>>,
     {
         self.title = Some(title.into());
         self
@@ -144,12 +144,12 @@ impl<'a> Block<'a> {
 
     #[deprecated(
         since = "0.10.0",
-        note = "You should use styling capabilities of `text::Spans` given as argument of the `title` method to apply styling to the title."
+        note = "You should use styling capabilities of `text::Line` given as argument of the `title` method to apply styling to the title."
     )]
     pub fn title_style(mut self, style: Style) -> Block<'a> {
         if let Some(t) = self.title {
             let title = String::from(t);
-            self.title = Some(Spans::from(Span::styled(title, style)));
+            self.title = Some(Line::from(Span::styled(title, style)));
         }
         self
     }
@@ -346,7 +346,7 @@ impl<'a> Widget for Block<'a> {
                 area.top()
             };
 
-            buf.set_spans(title_x, title_y, &title, title_area_width);
+            buf.set_line(title_x, title_y, &title, title_area_width);
         }
     }
 }

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -14,7 +14,7 @@ use crate::{
     buffer::Buffer,
     layout::Rect,
     style::Style,
-    text::{Span, Spans},
+    text::{Span, Line},
     widgets::{Block, Widget},
 };
 
@@ -128,7 +128,7 @@ impl<'a, S: DateStyler> Widget for Monthly<'a, S> {
             );
             // cal is 21 cells wide, so hard code the 11
             let x_off = 11_u16.saturating_sub(line.width() as u16 / 2);
-            buf.set_spans(area.x + x_off, area.y, &line.into(), area.width);
+            buf.set_line(area.x + x_off, area.y, &line.into(), area.width);
             area.y += 1
         }
 
@@ -146,7 +146,7 @@ impl<'a, S: DateStyler> Widget for Monthly<'a, S> {
 
         // go through all the weeks containing a day in the target month.
         while curr_day.month() as u8 != self.display_date.month().next() as u8 {
-            let mut line = Spans(Vec::with_capacity(14));
+            let mut line = Line(Vec::with_capacity(14));
             for i in 0..7 {
                 // Draw the gutter. Do it here so we can avoid worrying about
                 // styling the ' ' in the format_date method
@@ -158,7 +158,7 @@ impl<'a, S: DateStyler> Widget for Monthly<'a, S> {
                 line.0.push(self.format_date(curr_day));
                 curr_day += Duration::DAY;
             }
-            buf.set_spans(area.x, area.y, &line, area.width);
+            buf.set_line(area.x, area.y, &line, area.width);
             area.y += 1;
         }
     }

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -14,7 +14,7 @@ use crate::{
     buffer::Buffer,
     layout::Rect,
     style::Style,
-    text::{Span, Line},
+    text::{Line, Span},
     widgets::{Block, Widget},
 };
 

--- a/src/widgets/canvas/mod.rs
+++ b/src/widgets/canvas/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     layout::Rect,
     style::{Color, Style},
     symbols,
-    text::Spans,
+    text::Line as TextLine,
     widgets::{Block, Widget},
 };
 use std::fmt::Debug;
@@ -31,7 +31,7 @@ pub trait Shape {
 pub struct Label<'a> {
     x: f64,
     y: f64,
-    spans: Spans<'a>,
+    line: TextLine<'a>,
 }
 
 #[derive(Debug, Clone)]
@@ -299,14 +299,14 @@ impl<'a> Context<'a> {
     }
 
     /// Print a string on the canvas at the given position
-    pub fn print<T>(&mut self, x: f64, y: f64, spans: T)
+    pub fn print<T>(&mut self, x: f64, y: f64, line: T)
     where
-        T: Into<Spans<'a>>,
+        T: Into<TextLine<'a>>,
     {
         self.labels.push(Label {
             x,
             y,
-            spans: spans.into(),
+            line: line.into(),
         });
     }
 
@@ -510,7 +510,7 @@ where
         {
             let x = ((label.x - left) * resolution.0 / width) as u16 + canvas_area.left();
             let y = ((top - label.y) * resolution.1 / height) as u16 + canvas_area.top();
-            buf.set_spans(x, y, &label.spans, canvas_area.right() - x);
+            buf.set_line(x, y, &label.line, canvas_area.right() - x);
         }
     }
 }

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -8,9 +8,9 @@ use crate::{
     layout::{Constraint, Rect},
     style::{Color, Style},
     symbols,
-    text::{Span, Spans},
+    text::{Span, Line},
     widgets::{
-        canvas::{Canvas, Line, Points},
+        canvas::{Canvas, Line as ShapeLine, Points},
         Block, Borders, Widget,
     },
 };
@@ -19,7 +19,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct Axis<'a> {
     /// Title displayed next to axis end
-    title: Option<Spans<'a>>,
+    title: Option<Line<'a>>,
     /// Bounds for the axis (all data points outside these limits will not be represented)
     bounds: [f64; 2],
     /// A list of labels to put to the left or below the axis
@@ -45,7 +45,7 @@ impl<'a> Default for Axis<'a> {
 impl<'a> Axis<'a> {
     pub fn title<T>(mut self, title: T) -> Axis<'a>
     where
-        T: Into<Spans<'a>>,
+        T: Into<Line<'a>>,
     {
         self.title = Some(title.into());
         self
@@ -53,12 +53,12 @@ impl<'a> Axis<'a> {
 
     #[deprecated(
         since = "0.10.0",
-        note = "You should use styling capabilities of `text::Spans` given as argument of the `title` method to apply styling to the title."
+        note = "You should use styling capabilities of `text::Line` given as argument of the `title` method to apply styling to the title."
     )]
     pub fn title_style(mut self, style: Style) -> Axis<'a> {
         if let Some(t) = self.title {
             let title = String::from(t);
-            self.title = Some(Spans::from(Span::styled(title, style)));
+            self.title = Some(Line::from(Span::styled(title, style)));
         }
         self
     }
@@ -557,7 +557,7 @@ impl<'a> Widget for Chart<'a> {
                     });
                     if let GraphType::Line = dataset.graph_type {
                         for data in dataset.data.windows(2) {
-                            ctx.draw(&Line {
+                            ctx.draw(&ShapeLine {
                                 x1: data[0].0,
                                 y1: data[0].1,
                                 x2: data[1].0,
@@ -597,7 +597,7 @@ impl<'a> Widget for Chart<'a> {
                 },
                 original_style,
             );
-            buf.set_spans(x, y, &title, width);
+            buf.set_line(x, y, &title, width);
         }
 
         if let Some((x, y)) = layout.title_y {
@@ -612,7 +612,7 @@ impl<'a> Widget for Chart<'a> {
                 },
                 original_style,
             );
-            buf.set_spans(x, y, &title, width);
+            buf.set_line(x, y, &title, width);
         }
     }
 }

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -8,7 +8,7 @@ use crate::{
     layout::{Constraint, Rect},
     style::{Color, Style},
     symbols,
-    text::{Span, Line},
+    text::{Line, Span},
     widgets::{
         canvas::{Canvas, Line as ShapeLine, Points},
         Block, Borders, Widget,

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -3,7 +3,7 @@ use crate::{
     layout::Rect,
     style::{Color, Style},
     symbols,
-    text::{Span, Line},
+    text::{Line, Span},
     widgets::{Block, Widget},
 };
 

--- a/src/widgets/gauge.rs
+++ b/src/widgets/gauge.rs
@@ -3,7 +3,7 @@ use crate::{
     layout::Rect,
     style::{Color, Style},
     symbols,
-    text::{Span, Spans},
+    text::{Span, Line},
     widgets::{Block, Widget},
 };
 
@@ -174,7 +174,7 @@ fn get_unicode_block<'a>(frac: f64) -> &'a str {
 pub struct LineGauge<'a> {
     block: Option<Block<'a>>,
     ratio: f64,
-    label: Option<Spans<'a>>,
+    label: Option<Line<'a>>,
     line_set: symbols::line::Set,
     style: Style,
     gauge_style: Style,
@@ -215,7 +215,7 @@ impl<'a> LineGauge<'a> {
 
     pub fn label<T>(mut self, label: T) -> Self
     where
-        T: Into<Spans<'a>>,
+        T: Into<Line<'a>>,
     {
         self.label = Some(label.into());
         self
@@ -251,8 +251,8 @@ impl<'a> Widget for LineGauge<'a> {
         let ratio = self.ratio;
         let label = self
             .label
-            .unwrap_or_else(move || Spans::from(format!("{:.0}%", ratio * 100.0)));
-        let (col, row) = buf.set_spans(
+            .unwrap_or_else(move || Line::from(format!("{:.0}%", ratio * 100.0)));
+        let (col, row) = buf.set_line(
             gauge_area.left(),
             gauge_area.top(),
             &label,

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -292,7 +292,7 @@ mod tests {
     use crate::{
         assert_buffer_eq,
         style::Color,
-        text::{Span, Line},
+        text::{Line, Span},
         widgets::{Borders, StatefulWidget, Widget},
     };
 

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -269,7 +269,7 @@ impl<'a> StatefulWidget for List<'a> {
                 } else {
                     (x, list_area.width)
                 };
-                buf.set_spans(elem_x, y + j as u16, line, max_element_width);
+                buf.set_line(elem_x, y + j as u16, line, max_element_width);
             }
             if is_selected {
                 buf.set_style(area, self.highlight_style);
@@ -292,7 +292,7 @@ mod tests {
     use crate::{
         assert_buffer_eq,
         style::Color,
-        text::{Span, Spans},
+        text::{Span, Line},
         widgets::{Borders, StatefulWidget, Widget},
     };
 
@@ -355,24 +355,24 @@ mod tests {
     }
 
     #[test]
-    fn test_list_item_new_from_spans() {
-        let spans = Spans::from(vec![
+    fn test_list_item_new_from_line() {
+        let line = Line::from(vec![
             Span::styled("Test ", Style::default().fg(Color::Blue)),
             Span::styled("item", Style::default().fg(Color::Red)),
         ]);
-        let item = ListItem::new(spans.clone());
-        assert_eq!(item.content, Text::from(spans));
+        let item = ListItem::new(line.clone());
+        assert_eq!(item.content, Text::from(line));
         assert_eq!(item.style, Style::default());
     }
 
     #[test]
-    fn test_list_item_new_from_vec_spans() {
+    fn test_list_item_new_from_vec_line() {
         let lines = vec![
-            Spans::from(vec![
+            Line::from(vec![
                 Span::styled("Test ", Style::default().fg(Color::Blue)),
                 Span::styled("item", Style::default().fg(Color::Red)),
             ]),
-            Spans::from(vec![
+            Line::from(vec![
                 Span::styled("Second ", Style::default().fg(Color::Green)),
                 Span::styled("line", Style::default().fg(Color::Yellow)),
             ]),

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -150,8 +150,7 @@ impl<'a> Widget for Paragraph<'a> {
 
         let style = self.style;
         let mut styled = self.text.lines.iter().flat_map(|line| {
-            line
-                .0
+            line.0
                 .iter()
                 .flat_map(|span| span.styled_graphemes(style))
                 // Required given the way composers work but might be refactored out if we change
@@ -205,7 +204,7 @@ mod test {
     use super::*;
     use crate::{
         style::Color,
-        text::{Span, Line},
+        text::{Line, Span},
         widgets::Borders,
     };
 

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -24,17 +24,17 @@ fn get_line_offset(line_width: u16, text_area_width: u16, alignment: Alignment) 
 /// # Examples
 ///
 /// ```
-/// # use ratatui::text::{Text, Spans, Span};
+/// # use ratatui::text::{Text, Line, Span};
 /// # use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 /// # use ratatui::style::{Style, Color, Modifier};
 /// # use ratatui::layout::{Alignment};
 /// let text = vec![
-///     Spans::from(vec![
+///     Line::from(vec![
 ///         Span::raw("First"),
 ///         Span::styled("line",Style::default().add_modifier(Modifier::ITALIC)),
 ///         Span::raw("."),
 ///     ]),
-///     Spans::from(Span::styled("Second line", Style::default().fg(Color::Red))),
+///     Line::from(Span::styled("Second line", Style::default().fg(Color::Red))),
 /// ];
 /// Paragraph::new(text)
 ///     .block(Block::default().title("Paragraph").borders(Borders::ALL))
@@ -149,8 +149,8 @@ impl<'a> Widget for Paragraph<'a> {
         }
 
         let style = self.style;
-        let mut styled = self.text.lines.iter().flat_map(|spans| {
-            spans
+        let mut styled = self.text.lines.iter().flat_map(|line| {
+            line
                 .0
                 .iter()
                 .flat_map(|span| span.styled_graphemes(style))
@@ -205,7 +205,7 @@ mod test {
     use super::*;
     use crate::{
         style::Color,
-        text::{Span, Spans},
+        text::{Span, Line},
         widgets::Borders,
     };
 
@@ -386,7 +386,7 @@ mod test {
     fn test_render_paragraph_with_styled_text() {
         let mut buffer = Buffer::empty(Rect::new(0, 0, 13, 1));
 
-        Paragraph::new(Spans::from(vec![
+        Paragraph::new(Line::from(vec![
             Span::styled("Hello, ", Style::default().fg(Color::Red)),
             Span::styled("world!", Style::default().fg(Color::Blue)),
         ]))

--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -13,15 +13,15 @@ use unicode_width::UnicodeWidthStr;
 /// ```rust
 /// # use ratatui::widgets::Cell;
 /// # use ratatui::style::{Style, Modifier};
-/// # use ratatui::text::{Span, Spans, Text};
+/// # use ratatui::text::{Span, Line, Text};
 /// # use std::borrow::Cow;
 /// Cell::from("simple string");
 ///
 /// Cell::from(Span::from("span"));
 ///
-/// Cell::from(Spans::from(vec![
+/// Cell::from(Line::from(vec![
 ///     Span::raw("a vec of "),
-///     Span::styled("spans", Style::default().add_modifier(Modifier::BOLD))
+///     Span::styled("line", Style::default().add_modifier(Modifier::BOLD))
 /// ]));
 ///
 /// Cell::from(Text::from("a text"));
@@ -142,7 +142,7 @@ impl<'a> Row<'a> {
 /// # use ratatui::widgets::{Block, Borders, Table, Row, Cell};
 /// # use ratatui::layout::Constraint;
 /// # use ratatui::style::{Style, Color, Modifier};
-/// # use ratatui::text::{Text, Spans, Span};
+/// # use ratatui::text::{Text, Line, Span};
 /// Table::new(vec![
 ///     // Row can be created from simple strings.
 ///     Row::new(vec!["Row11", "Row12", "Row13"]),
@@ -152,7 +152,7 @@ impl<'a> Row<'a> {
 ///     Row::new(vec![
 ///         Cell::from("Row31"),
 ///         Cell::from("Row32").style(Style::default().fg(Color::Yellow)),
-///         Cell::from(Spans::from(vec![
+///         Cell::from(Line::from(vec![
 ///             Span::raw("Row"),
 ///             Span::styled("33", Style::default().fg(Color::Green))
 ///         ])),
@@ -477,11 +477,11 @@ impl<'a> StatefulWidget for Table<'a> {
 
 fn render_cell(buf: &mut Buffer, cell: &Cell, area: Rect) {
     buf.set_style(area, cell.style);
-    for (i, spans) in cell.content.lines.iter().enumerate() {
+    for (i, line) in cell.content.lines.iter().enumerate() {
         if i as u16 >= area.height {
             break;
         }
-        buf.set_spans(area.x, area.y + i as u16, spans, area.width);
+        buf.set_line(area.x, area.y + i as u16, line, area.width);
     }
 }
 

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -3,7 +3,7 @@ use crate::{
     layout::Rect,
     style::Style,
     symbols,
-    text::{Span, Line},
+    text::{Line, Span},
     widgets::{Block, Widget},
 };
 

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -3,7 +3,7 @@ use crate::{
     layout::Rect,
     style::Style,
     symbols,
-    text::{Span, Spans},
+    text::{Span, Line},
     widgets::{Block, Widget},
 };
 
@@ -14,9 +14,9 @@ use crate::{
 /// ```
 /// # use ratatui::widgets::{Block, Borders, Tabs};
 /// # use ratatui::style::{Style, Color};
-/// # use ratatui::text::{Spans};
+/// # use ratatui::text::{Line};
 /// # use ratatui::symbols::{DOT};
-/// let titles = ["Tab1", "Tab2", "Tab3", "Tab4"].iter().cloned().map(Spans::from).collect();
+/// let titles = ["Tab1", "Tab2", "Tab3", "Tab4"].iter().cloned().map(Line::from).collect();
 /// Tabs::new(titles)
 ///     .block(Block::default().title("Tabs").borders(Borders::ALL))
 ///     .style(Style::default().fg(Color::White))
@@ -28,7 +28,7 @@ pub struct Tabs<'a> {
     /// A block to wrap this widget in if necessary
     block: Option<Block<'a>>,
     /// One title for each tab
-    titles: Vec<Spans<'a>>,
+    titles: Vec<Line<'a>>,
     /// The index of the selected tabs
     selected: usize,
     /// The style used to draw the text
@@ -40,7 +40,7 @@ pub struct Tabs<'a> {
 }
 
 impl<'a> Tabs<'a> {
-    pub fn new(titles: Vec<Spans<'a>>) -> Tabs<'a> {
+    pub fn new(titles: Vec<Line<'a>>) -> Tabs<'a> {
         Tabs {
             block: None,
             titles,
@@ -105,7 +105,7 @@ impl<'a> Widget for Tabs<'a> {
             if remaining_width == 0 {
                 break;
             }
-            let pos = buf.set_spans(x, tabs_area.top(), &title, remaining_width);
+            let pos = buf.set_line(x, tabs_area.top(), &title, remaining_width);
             if i == self.selected {
                 buf.set_style(
                     Rect {

--- a/tests/widgets_list.rs
+++ b/tests/widgets_list.rs
@@ -4,7 +4,7 @@ use ratatui::{
     layout::Rect,
     style::{Color, Style},
     symbols,
-    text::Spans,
+    text::Line,
     widgets::{Block, Borders, List, ListItem, ListState},
     Terminal,
 };
@@ -154,9 +154,9 @@ fn widgets_list_should_display_multiline_items() {
         .draw(|f| {
             let size = f.size();
             let items = vec![
-                ListItem::new(vec![Spans::from("Item 1"), Spans::from("Item 1a")]),
-                ListItem::new(vec![Spans::from("Item 2"), Spans::from("Item 2b")]),
-                ListItem::new(vec![Spans::from("Item 3"), Spans::from("Item 3c")]),
+                ListItem::new(vec![Line::from("Item 1"), Line::from("Item 1a")]),
+                ListItem::new(vec![Line::from("Item 2"), Line::from("Item 2b")]),
+                ListItem::new(vec![Line::from("Item 3"), Line::from("Item 3c")]),
             ];
             let list = List::new(items)
                 .highlight_style(Style::default().bg(Color::Yellow))
@@ -189,9 +189,9 @@ fn widgets_list_should_repeat_highlight_symbol() {
         .draw(|f| {
             let size = f.size();
             let items = vec![
-                ListItem::new(vec![Spans::from("Item 1"), Spans::from("Item 1a")]),
-                ListItem::new(vec![Spans::from("Item 2"), Spans::from("Item 2b")]),
-                ListItem::new(vec![Spans::from("Item 3"), Spans::from("Item 3c")]),
+                ListItem::new(vec![Line::from("Item 1"), Line::from("Item 1a")]),
+                ListItem::new(vec![Line::from("Item 2"), Line::from("Item 2b")]),
+                ListItem::new(vec![Line::from("Item 3"), Line::from("Item 3c")]),
             ];
             let list = List::new(items)
                 .highlight_style(Style::default().bg(Color::Yellow))

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -2,7 +2,7 @@ use ratatui::{
     backend::TestBackend,
     buffer::Buffer,
     layout::Alignment,
-    text::{Span, Spans, Text},
+    text::{Span, Line, Text},
     widgets::{Block, Borders, Padding, Paragraph, Wrap},
     Terminal,
 };
@@ -21,7 +21,7 @@ fn widgets_paragraph_can_wrap_its_content() {
         terminal
             .draw(|f| {
                 let size = f.size();
-                let text = vec![Spans::from(SAMPLE_STRING)];
+                let text = vec![Line::from(SAMPLE_STRING)];
                 let paragraph = Paragraph::new(text)
                     .block(Block::default().borders(Borders::ALL).padding(Padding {
                         left: 2,
@@ -99,7 +99,7 @@ fn widgets_paragraph_renders_double_width_graphemes() {
     terminal
         .draw(|f| {
             let size = f.size();
-            let text = vec![Spans::from(s)];
+            let text = vec![Line::from(s)];
             let paragraph = Paragraph::new(text)
                 .block(Block::default().borders(Borders::ALL))
                 .wrap(Wrap { trim: true });
@@ -131,7 +131,7 @@ fn widgets_paragraph_renders_mixed_width_graphemes() {
     terminal
         .draw(|f| {
             let size = f.size();
-            let text = vec![Spans::from(s)];
+            let text = vec![Line::from(s)];
             let paragraph = Paragraph::new(text)
                 .block(Block::default().borders(Borders::ALL))
                 .wrap(Wrap { trim: true });
@@ -155,7 +155,7 @@ fn widgets_paragraph_renders_mixed_width_graphemes() {
 #[test]
 fn widgets_paragraph_can_wrap_with_a_trailing_nbsp() {
     let nbsp: &str = "\u{00a0}";
-    let line = Spans::from(vec![Span::raw("NBSP"), Span::raw(nbsp)]);
+    let line = Line::from(vec![Span::raw("NBSP"), Span::raw(nbsp)]);
     let backend = TestBackend::new(20, 3);
     let mut terminal = Terminal::new(backend).unwrap();
     let expected = Buffer::with_lines(vec![

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -2,7 +2,7 @@ use ratatui::{
     backend::TestBackend,
     buffer::Buffer,
     layout::Alignment,
-    text::{Span, Line, Text},
+    text::{Line, Span, Text},
     widgets::{Block, Borders, Padding, Paragraph, Wrap},
     Terminal,
 };

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -3,7 +3,7 @@ use ratatui::{
     buffer::Buffer,
     layout::Constraint,
     style::{Color, Modifier, Style},
-    text::{Span, Spans},
+    text::{Span, Line},
     widgets::{Block, Borders, Cell, Row, Table, TableState},
     Terminal,
 };
@@ -623,7 +623,7 @@ fn widgets_table_can_have_elements_styled_individually() {
                 Row::new(vec![
                     Cell::from("Row21"),
                     Cell::from("Row22").style(Style::default().fg(Color::Yellow)),
-                    Cell::from(Spans::from(vec![
+                    Cell::from(Line::from(vec![
                         Span::raw("Row"),
                         Span::styled("23", Style::default().fg(Color::Blue)),
                     ]))

--- a/tests/widgets_table.rs
+++ b/tests/widgets_table.rs
@@ -3,7 +3,7 @@ use ratatui::{
     buffer::Buffer,
     layout::Constraint,
     style::{Color, Modifier, Style},
-    text::{Span, Line},
+    text::{Line, Span},
     widgets::{Block, Borders, Cell, Row, Table, TableState},
     Terminal,
 };

--- a/tests/widgets_tabs.rs
+++ b/tests/widgets_tabs.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    backend::TestBackend, buffer::Buffer, layout::Rect, symbols, text::Spans, widgets::Tabs,
+    backend::TestBackend, buffer::Buffer, layout::Rect, symbols, text::Line, widgets::Tabs,
     Terminal,
 };
 
@@ -9,7 +9,7 @@ fn widgets_tabs_should_not_panic_on_narrow_areas() {
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|f| {
-            let tabs = Tabs::new(["Tab1", "Tab2"].iter().cloned().map(Spans::from).collect());
+            let tabs = Tabs::new(["Tab1", "Tab2"].iter().cloned().map(Line::from).collect());
             f.render_widget(
                 tabs,
                 Rect {
@@ -31,7 +31,7 @@ fn widgets_tabs_should_truncate_the_last_item() {
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|f| {
-            let tabs = Tabs::new(["Tab1", "Tab2"].iter().cloned().map(Spans::from).collect());
+            let tabs = Tabs::new(["Tab1", "Tab2"].iter().cloned().map(Line::from).collect());
             f.render_widget(
                 tabs,
                 Rect {


### PR DESCRIPTION
Because `Spans` conflicts with the plural `Span`s, and because the type represents a line of text, I've renamed it to `Line`. I will also be adding a deprecated type alias to avoid breaking existing codebases (haven't committed it yet).