### PR TITLE
feat(widget): add `offset()` to `ListState`

### DIFF
--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -24,6 +24,13 @@ impl ListState {
         self
     }
 
+    /// Returns a copy of the receiver's scroll offset.
+    ///
+    /// This is useful, for example, if you need to "synchronize" the scrolling of a `List` and a `Paragraph`.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
     pub fn selected(&self) -> Option<usize> {
         self.selected
     }


### PR DESCRIPTION
This PR implements a getter method `offset` for `ListState`, similarly to `TableState` (#10)