### PR TITLE
chore: inline format args

### DIFF
--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -81,7 +81,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -115,7 +115,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -117,7 +117,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/demo/crossterm.rs
+++ b/examples/demo/crossterm.rs
@@ -36,7 +36,7 @@ pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<(), Box<dyn E
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/demo/termion.rs
+++ b/examples/demo/termion.rs
@@ -67,14 +67,14 @@ fn events(tick_rate: Duration) -> mpsc::Receiver<Event> {
         let stdin = io::stdin();
         for key in stdin.keys().flatten() {
             if let Err(err) = keys_tx.send(Event::Input(key)) {
-                eprintln!("{}", err);
+                eprintln!("{err}");
                 return;
             }
         }
     });
     thread::spawn(move || loop {
         if let Err(err) = tx.send(Event::Tick) {
-            eprintln!("{}", err);
+            eprintln!("{err}");
             break;
         }
         thread::sleep(tick_rate);

--- a/examples/demo/termwiz.rs
+++ b/examples/demo/termwiz.rs
@@ -21,7 +21,7 @@ pub fn run(tick_rate: Duration, enhanced_graphics: bool) -> Result<(), Box<dyn E
     terminal.flush()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -162,7 +162,7 @@ where
                         _ => info_style,
                     };
                     let content = vec![Line::from(vec![
-                        Span::styled(format!("{:<9}", level), s),
+                        Span::styled(format!("{level:<9}"), s),
                         Span::raw(evt),
                     ])];
                     ListItem::new(content)
@@ -417,7 +417,7 @@ where
         .iter()
         .map(|c| {
             let cells = vec![
-                Cell::from(Span::raw(format!("{:?}: ", c))),
+                Cell::from(Span::raw(format!("{c:?}: "))),
                 Cell::from(Span::styled("Foreground", Style::default().fg(*c))),
                 Cell::from(Span::styled("Background", Style::default().bg(*c))),
             ];

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -196,7 +196,7 @@ fn run_app<B: Backend>(
                     Paragraph::new(Line::from(vec![
                         Span::from("Finished "),
                         Span::styled(
-                            format!("download {}", download_id),
+                            format!("download {download_id}"),
                             Style::default().add_modifier(Modifier::BOLD),
                         ),
                         Span::from(format!(
@@ -240,7 +240,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, downloads: &Downloads) {
     let done = NUM_DOWNLOADS - downloads.pending.len() - downloads.in_progress.len();
     let progress = LineGauge::default()
         .gauge_style(Style::default().fg(Color::Blue))
-        .label(format!("{}/{}", done, NUM_DOWNLOADS))
+        .label(format!("{done}/{NUM_DOWNLOADS}"))
         .ratio(done as f64 / NUM_DOWNLOADS as f64);
     f.render_widget(progress, chunks[0]);
 

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -166,7 +166,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())
@@ -258,7 +258,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &mut App) {
             };
             // Add a example datetime and apply proper spacing between them
             let header = Line::from(vec![
-                Span::styled(format!("{:<9}", level), s),
+                Span::styled(format!("{level:<9}"), s),
                 Span::raw(" "),
                 Span::styled(
                     "2020-01-01 10:00:00",

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -55,7 +55,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -99,7 +99,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     terminal.show_cursor()?;
 
     if let Err(err) = res {
-        println!("{:?}", err)
+        println!("{err:?}");
     }
 
     Ok(())
@@ -183,7 +183,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
         .iter()
         .enumerate()
         .map(|(i, m)| {
-            let content = Line::from(Span::raw(format!("{}: {}", i, m)));
+            let content = Line::from(Span::raw(format!("{i}: {m}")));
             ListItem::new(content)
         })
         .collect();

--- a/src/backend/termion.rs
+++ b/src/backend/termion.rs
@@ -128,8 +128,7 @@ where
         }
         write!(
             self.stdout,
-            "{}{}{}{}",
-            string,
+            "{string}{}{}{}",
             Fg(Color::Reset),
             Bg(Color::Reset),
             termion::style::Reset,

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -96,7 +96,7 @@ impl TestBackend {
             .collect::<Vec<String>>()
             .join("\n");
         debug_info.push_str(&nice_diff);
-        panic!("{}", debug_info);
+        panic!("{debug_info}");
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -214,9 +214,7 @@ impl Buffer {
                 && x < self.area.right()
                 && y >= self.area.top()
                 && y < self.area.bottom(),
-            "Trying to access position outside the buffer: x={}, y={}, area={:?}",
-            x,
-            y,
+            "Trying to access position outside the buffer: x={x}, y={y}, area={:?}",
             self.area
         );
         ((y - self.area.y) * self.area.width + (x - self.area.x)) as usize
@@ -252,8 +250,7 @@ impl Buffer {
     pub fn pos_of(&self, i: usize) -> (u16, u16) {
         debug_assert!(
             i < self.content.len(),
-            "Trying to get the coords of a cell outside the buffer: i={} len={}",
-            i,
+            "Trying to get the coords of a cell outside the buffer: i={i} len={}",
             self.content.len()
         );
         (
@@ -506,10 +503,7 @@ macro_rules! assert_buffer_eq {
                         .enumerate()
                         .map(|(i, (x, y, cell))| {
                             let expected_cell = expected.get(*x, *y);
-                            format!(
-                                "{}: at ({}, {})\n  expected: {:?}\n  actual:   {:?}",
-                                i, x, y, expected_cell, cell
-                            )
+                            format!("{i}: at ({x}, {y})\n  expected: {expected_cell:?}\n  actual:   {cell:?}")
                         })
                         .collect::<Vec<String>>()
                         .join("\n");

--- a/src/style.rs
+++ b/src/style.rs
@@ -424,8 +424,7 @@ mod tests {
         for bad_color in bad_colors {
             assert!(
                 Color::from_str(bad_color).is_err(),
-                "bad color: '{}'",
-                bad_color
+                "bad color: '{bad_color}'"
             );
         }
     }


### PR DESCRIPTION
Applied auto-clippy fix and some manual minor cleanup:

```
cargo clippy --all-features --benches --examples --tests --workspace --fix -- -A clippy::all -W clippy::uninlined_format_args
```
