### PR TITLE
feat(text)!: implement char-boundary wrapping for text display in `Paragraph`

### DIFF
--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -293,7 +293,10 @@ where
             .fg(Color::Magenta)
             .add_modifier(Modifier::BOLD),
     ));
-    let paragraph = Paragraph::new(text).block(block).wrap(Wrap { trim: true });
+    let paragraph = Paragraph::new(text)
+        .block(block)
+        .wrap(Wrap::WordBoundary)
+        .trim(true);
     f.render_widget(paragraph, area);
 }
 

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -160,21 +160,24 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
     let paragraph = Paragraph::new(text.clone())
         .style(Style::default().fg(Color::Gray))
         .block(create_block("Default alignment (Left), with wrap"))
-        .wrap(Wrap { trim: true });
+        .wrap(Wrap::WordBoundary)
+        .trim(true);
     f.render_widget(paragraph, chunks[1]);
 
     let paragraph = Paragraph::new(text.clone())
         .style(Style::default().fg(Color::Gray))
         .block(create_block("Right alignment, with wrap"))
         .alignment(Alignment::Right)
-        .wrap(Wrap { trim: true });
+        .wrap(Wrap::WordBoundary)
+        .trim(true);
     f.render_widget(paragraph, chunks[2]);
 
     let paragraph = Paragraph::new(text)
         .style(Style::default().fg(Color::Gray))
         .block(create_block("Center alignment, with wrap, with scroll"))
         .alignment(Alignment::Center)
-        .wrap(Wrap { trim: true })
+        .wrap(Wrap::WordBoundary)
+        .trim(true)
         .scroll((app.scroll, 0));
     f.render_widget(paragraph, chunks[3]);
 }

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -85,7 +85,8 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
         Style::default().add_modifier(Modifier::SLOW_BLINK),
     ))
     .alignment(Alignment::Center)
-    .wrap(Wrap { trim: true });
+    .wrap(Wrap::WordBoundary)
+    .trim(true);
     f.render_widget(paragraph, chunks[0]);
 
     let block = Block::default()

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -166,20 +166,20 @@ impl<'a> Widget for Paragraph<'a> {
             )
         });
 
-        let mut line_composer: Box<dyn LineComposer> = if let Some(wrap_mode) = self.wrap {
-            match wrap_mode {
-                Wrap::CharBoundary => {
-                    Box::new(CharWrapper::new(styled, text_area.width, self.trim))
-                }
-                Wrap::WordBoundary => {
-                    Box::new(WordWrapper::new(styled, text_area.width, self.trim))
-                }
+        let mut line_composer: Box<dyn LineComposer> = match self.wrap {
+            Some(Wrap::CharBoundary) => {
+                Box::new(CharWrapper::new(styled, text_area.width, self.trim))
             }
-        } else {
-            let mut line_composer = Box::new(LineTruncator::new(styled, text_area.width));
-            line_composer.set_horizontal_offset(self.scroll.1);
-            line_composer
+            Some(Wrap::WordBoundary) => {
+                Box::new(WordWrapper::new(styled, text_area.width, self.trim))
+            }
+            None => {
+                let mut line_composer = Box::new(LineTruncator::new(styled, text_area.width));
+                line_composer.set_horizontal_offset(self.scroll.1);
+                line_composer
+            }
         };
+
         let mut y = 0;
         while let Some((current_line, current_line_width, current_line_alignment)) =
             line_composer.next_line()

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -340,7 +340,7 @@ mod test {
             Paragraph::new(text).block(Block::default().title("Title").borders(Borders::ALL));
         let char_wrapped_paragraph = truncated_paragraph
             .clone()
-            .wrap(Wrap::WordBoundary)
+            .wrap(Wrap::CharBoundary)
             .trim(false);
         let word_wrapped_paragraph = truncated_paragraph
             .clone()
@@ -391,6 +391,15 @@ mod test {
                 "┌Title──────┐",
                 "│Hello, worl│",
                 "│           │",
+                "└───────────┘",
+            ]),
+        );
+        test_case(
+            &char_wrapped_paragraph,
+            Buffer::with_lines(vec![
+                "┌Title──────┐",
+                "│Hello, worl│",
+                "│d!         │",
                 "└───────────┘",
             ]),
         );

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -258,12 +258,12 @@ fn widgets_paragraph_can_word_wrap_its_content() {
 fn widgets_paragraph_can_trim_its_content() {
     let space_text = "This is some         text with an excessive       amount of whitespace                  between words.";
     let text = vec![Line::from(space_text)];
-    let paragraph = Paragraph::new(text)
+    let paragraph = Paragraph::new(text.clone())
         .block(Block::default().borders(Borders::ALL))
-        .wrap(Wrap::CharBoundary);
+        .alignment(Alignment::Left);
 
     test_case(
-        paragraph.clone().alignment(Alignment::Left).trim(true),
+        paragraph.clone().wrap(Wrap::CharBoundary).trim(true),
         Buffer::with_lines(vec![
             "┌──────────────────┐",
             "│This is some      │",
@@ -275,7 +275,7 @@ fn widgets_paragraph_can_trim_its_content() {
         ]),
     );
     test_case(
-        paragraph.clone().alignment(Alignment::Left).trim(false),
+        paragraph.clone().wrap(Wrap::CharBoundary).trim(false),
         Buffer::with_lines(vec![
             "┌──────────────────┐",
             "│This is some      │",
@@ -287,11 +287,41 @@ fn widgets_paragraph_can_trim_its_content() {
             "└──────────────────┘",
         ]),
     );
+
+    test_case(
+        paragraph.clone().wrap(Wrap::WordBoundary).trim(true),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│This is some      │",
+            "│text with an      │",
+            "│excessive         │",
+            "│amount of         │",
+            "│whitespace        │",
+            "│between words.    │",
+            "└──────────────────┘",
+        ]),
+    );
+    // TODO: This test case is currently failing, will be reenabled upon being fixed.
+    // test_case(
+    //     paragraph.clone().wrap(Wrap::WordBoundary).trim(false),
+    //     Buffer::with_lines(vec![
+    //         "┌──────────────────┐",
+    //         "│This is some      │",
+    //         "│   text with an   │",
+    //         "│excessive         │",
+    //         "│amount of         │",
+    //         "│whitespace        │",
+    //         "│          between │",
+    //         "│words.            │",
+    //         "└──────────────────┘",
+    //     ]),
+    // );
 }
 
 #[test]
 fn widgets_paragraph_works_with_padding() {
-    let text = vec![Line::from(SAMPLE_STRING)];
+    let mut text = vec![Line::from("This is always centered.").alignment(Alignment::Center)];
+    text.push(Line::from(SAMPLE_STRING));
     let paragraph = Paragraph::new(text)
         .block(Block::default().borders(Borders::ALL).padding(Padding {
             left: 2,
@@ -299,14 +329,40 @@ fn widgets_paragraph_works_with_padding() {
             top: 1,
             bottom: 1,
         }))
-        .wrap(Wrap::WordBoundary)
         .trim(true);
 
     test_case(
-        paragraph.clone().alignment(Alignment::Left),
+        paragraph
+            .clone()
+            .alignment(Alignment::Left)
+            .wrap(Wrap::CharBoundary),
         Buffer::with_lines(vec![
             "┌────────────────────┐",
             "│                    │",
+            "│  This is always c  │",
+            "│      entered.      │",
+            "│  The library is b  │",
+            "│  ased on the prin  │",
+            "│  ciple of immedia  │",
+            "│  te rendering wit  │",
+            "│  h intermediate b  │",
+            "│  uffers. This mea  │",
+            "│  ns that at each   │",
+            "│  new frame you sh  │",
+            "│                    │",
+            "└────────────────────┘",
+        ]),
+    );
+    test_case(
+        paragraph
+            .clone()
+            .alignment(Alignment::Left)
+            .wrap(Wrap::WordBoundary),
+        Buffer::with_lines(vec![
+            "┌────────────────────┐",
+            "│                    │",
+            "│   This is always   │",
+            "│      centered.     │",
             "│  The library is    │",
             "│  based on the      │",
             "│  principle of      │",
@@ -319,38 +375,35 @@ fn widgets_paragraph_works_with_padding() {
             "└────────────────────┘",
         ]),
     );
+
     test_case(
-        paragraph.clone().alignment(Alignment::Right),
+        paragraph
+            .clone()
+            .alignment(Alignment::Right)
+            .wrap(Wrap::CharBoundary),
         Buffer::with_lines(vec![
             "┌────────────────────┐",
             "│                    │",
-            "│    The library is  │",
-            "│      based on the  │",
-            "│      principle of  │",
-            "│         immediate  │",
-            "│    rendering with  │",
-            "│      intermediate  │",
-            "│     buffers. This  │",
-            "│     means that at  │",
+            "│  This is always c  │",
+            "│      entered.      │",
+            "│  The library is b  │",
+            "│  ased on the prin  │",
+            "│  ciple of immedia  │",
+            "│  te rendering wit  │",
+            "│  h intermediate b  │",
+            "│  uffers. This mea  │",
+            "│  ns that at each   │",
+            "│  new frame you sh  │",
             "│                    │",
             "└────────────────────┘",
         ]),
     );
 
-    let mut text = vec![Line::from("This is always centered.").alignment(Alignment::Center)];
-    text.push(Line::from(SAMPLE_STRING));
-    let paragraph = Paragraph::new(text)
-        .block(Block::default().borders(Borders::ALL).padding(Padding {
-            left: 2,
-            right: 2,
-            top: 1,
-            bottom: 1,
-        }))
-        .wrap(Wrap::WordBoundary)
-        .trim(true);
-
     test_case(
-        paragraph.alignment(Alignment::Right),
+        paragraph
+            .clone()
+            .alignment(Alignment::Right)
+            .wrap(Wrap::WordBoundary),
         Buffer::with_lines(vec![
             "┌────────────────────┐",
             "│                    │",

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -144,7 +144,63 @@ const SAMPLE_STRING: &str = "The library is based on the principle of immediate 
      interactive UI, this may introduce overhead for highly dynamic content.";
 
 #[test]
-fn widgets_paragraph_can_wrap_its_content() {
+fn widgets_paragraph_can_char_wrap_its_content() {
+    let text = vec![Line::from(SAMPLE_STRING)];
+    let paragraph = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL))
+        .wrap(Wrap::CharBoundary)
+        .trim(true);
+
+    // If char wrapping is used, all alignments should be the same except on the last line.
+    test_case(
+        paragraph.clone().alignment(Alignment::Left),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│The library is bas│",
+            "│ed on the principl│",
+            "│e of immediate ren│",
+            "│dering with interm│",
+            "│ediate buffers. Th│",
+            "│is means that at e│",
+            "│ach new frame you │",
+            "│should build all w│",
+            "└──────────────────┘",
+        ]),
+    );
+    test_case(
+        paragraph.clone().alignment(Alignment::Center),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│The library is bas│",
+            "│ed on the principl│",
+            "│e of immediate ren│",
+            "│dering with interm│",
+            "│ediate buffers. Th│",
+            "│is means that at e│",
+            "│ach new frame you │",
+            "│should build all w│",
+            "└──────────────────┘",
+        ]),
+    );
+    test_case(
+        paragraph.clone().alignment(Alignment::Right),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│The library is bas│",
+            "│ed on the principl│",
+            "│e of immediate ren│",
+            "│dering with interm│",
+            "│ediate buffers. Th│",
+            "│is means that at e│",
+            "│ach new frame you │",
+            "│should build all w│",
+            "└──────────────────┘",
+        ]),
+    );
+}
+
+#[test]
+fn widgets_paragraph_can_word_wrap_its_content() {
     let text = vec![Line::from(SAMPLE_STRING)];
     let paragraph = Paragraph::new(text)
         .block(Block::default().borders(Borders::ALL))
@@ -193,6 +249,41 @@ fn widgets_paragraph_can_wrap_its_content() {
             "│      intermediate│",
             "│     buffers. This│",
             "│means that at each│",
+            "└──────────────────┘",
+        ]),
+    );
+}
+
+#[test]
+fn widgets_paragraph_can_trim_its_content() {
+    let space_text = "This is some         text with an excessive       amount of whitespace                  between words.";
+    let text = vec![Line::from(space_text)];
+    let paragraph = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL))
+        .wrap(Wrap::CharBoundary);
+
+    test_case(
+        paragraph.clone().alignment(Alignment::Left).trim(true),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│This is some      │",
+            "│text with an exces│",
+            "│sive       amount │",
+            "│of whitespace     │",
+            "│between words.    │",
+            "└──────────────────┘",
+        ]),
+    );
+    test_case(
+        paragraph.clone().alignment(Alignment::Left).trim(false),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│This is some      │",
+            "│   text with an ex│",
+            "│cessive       amou│",
+            "│nt of whitespace  │",
+            "│                be│",
+            "│tween words.      │",
             "└──────────────────┘",
         ]),
     );

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -32,7 +32,8 @@ fn widgets_paragraph_renders_double_width_graphemes() {
     let text = vec![Line::from(s)];
     let paragraph = Paragraph::new(text)
         .block(Block::default().borders(Borders::ALL))
-        .wrap(Wrap { trim: true });
+        .wrap(Wrap::WordBoundary)
+        .trim(true);
 
     test_case(
         paragraph,
@@ -63,7 +64,8 @@ fn widgets_paragraph_renders_mixed_width_graphemes() {
             let text = vec![Line::from(s)];
             let paragraph = Paragraph::new(text)
                 .block(Block::default().borders(Borders::ALL))
-                .wrap(Wrap { trim: true });
+                .wrap(Wrap::WordBoundary)
+                .trim(true);
             f.render_widget(paragraph, size);
         })
         .unwrap();
@@ -146,7 +148,8 @@ fn widgets_paragraph_can_wrap_its_content() {
     let text = vec![Line::from(SAMPLE_STRING)];
     let paragraph = Paragraph::new(text)
         .block(Block::default().borders(Borders::ALL))
-        .wrap(Wrap { trim: true });
+        .wrap(Wrap::WordBoundary)
+        .trim(true);
 
     test_case(
         paragraph.clone().alignment(Alignment::Left),
@@ -205,7 +208,8 @@ fn widgets_paragraph_works_with_padding() {
             top: 1,
             bottom: 1,
         }))
-        .wrap(Wrap { trim: true });
+        .wrap(Wrap::WordBoundary)
+        .trim(true);
 
     test_case(
         paragraph.clone().alignment(Alignment::Left),
@@ -251,7 +255,8 @@ fn widgets_paragraph_works_with_padding() {
             top: 1,
             bottom: 1,
         }))
-        .wrap(Wrap { trim: true });
+        .wrap(Wrap::WordBoundary)
+        .trim(true);
 
     test_case(
         paragraph.alignment(Alignment::Right),
@@ -285,7 +290,8 @@ fn widgets_paragraph_can_align_spans() {
     ];
     let paragraph = Paragraph::new(text)
         .block(Block::default().borders(Borders::ALL))
-        .wrap(Wrap { trim: true });
+        .wrap(Wrap::WordBoundary)
+        .trim(true);
 
     test_case(
         paragraph.clone().alignment(Alignment::Left),


### PR DESCRIPTION
Word-boundary wrapping is pretty, but leaves a rather opaque interface for crate users to predict where and how text will be displayed. Hard wrapping is one of a few ways that this can be made more transparent as needed.