### PR TITLE
fix(reflow): remove debug macro call

### DIFF
--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -182,7 +182,6 @@ where
                         // Append empty line if there was nothing to wrap in the first place
                         wrapped_lines.push(vec![]);
                     }
-                    dbg!(&wrapped_lines);
 
                     self.wrapped_lines = Some(wrapped_lines.into_iter());
                 } else {


### PR DESCRIPTION
This was accidentally left in the previous commit and causes all the
demos to fail.
