### PR TITLE
style(comments): set comment length to wrap at 100 chars

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -63,9 +63,9 @@ impl<T> StatefulList<T> {
     }
 }
 
-/// This struct holds the current state of the app. In particular, it has the `items` field which is a wrapper
-/// around `ListState`. Keeping track of the items state let us render the associated widget with its state
-/// and have access to features such as natural scrolling.
+/// This struct holds the current state of the app. In particular, it has the `items` field which is
+/// a wrapper around `ListState`. Keeping track of the items state let us render the associated
+/// widget with its state and have access to features such as natural scrolling.
 ///
 /// Check the event handling at the bottom to see how to change the state on incoming events.
 /// Check the drawing logic for items on how to specify the highlighting style for selected items.

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -168,7 +168,8 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
             {}
 
         InputMode::Editing => {
-            // Make the cursor visible and ask ratatui to put it at the specified coordinates after rendering
+            // Make the cursor visible and ask ratatui to put it at the specified coordinates after
+            // rendering
             f.set_cursor(
                 // Put cursor past the end of the input text
                 chunks[1].x + app.input.width() as u16 + 1,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+wrap_comments = true
+comment_width = 100

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -459,8 +459,8 @@ impl Buffer {
         let mut updates: Vec<(u16, u16, &Cell)> = vec![];
         // Cells invalidated by drawing/replacing preceding multi-width characters:
         let mut invalidated: usize = 0;
-        // Cells from the current buffer to skip due to preceding multi-width characters taking their
-        // place (the skipped cells should be blank anyway):
+        // Cells from the current buffer to skip due to preceding multi-width characters taking
+        // their place (the skipped cells should be blank anyway):
         let mut to_skip: usize = 0;
         for (i, (current, previous)) in next_buffer.iter().zip(previous_buffer.iter()).enumerate() {
             if (current != previous || invalidated > 0) && to_skip == 0 {
@@ -538,7 +538,7 @@ impl Debug for Buffer {
     /// * `area`: displayed as `Rect { x: 1, y: 2, width: 3, height: 4 }`
     /// * `content`: displayed as a list of strings representing the content of the buffer
     /// * `styles`: displayed as a list of: `{ x: 1, y: 2, fg: Color::Red, bg: Color::Blue,
-    ///     modifier: Modifier::BOLD }` only showing a value when there is a change in style.
+    ///   modifier: Modifier::BOLD }` only showing a value when there is a change in style.
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         f.write_fmt(format_args!(
             "Buffer {{\n    area: {:?},\n    content: [\n",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 //! [dependencies]
 //! termion = "1.5"
 //! ratatui = { version = "0.20", default-features = false, features = ['termion'] }
-//!
 //! ```
 //!
 //! The same logic applies for all other available backends.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -356,8 +356,8 @@ where
     /// Insert some content before the current inline viewport. This has no effect when the
     /// viewport is fullscreen.
     ///
-    /// This function scrolls down the current viewport by the given height. The newly freed space is
-    /// then made available to the `draw_fn` closure through a writable `Buffer`.
+    /// This function scrolls down the current viewport by the given height. The newly freed space
+    /// is then made available to the `draw_fn` closure through a writable `Buffer`.
     ///
     /// Before:
     /// ```ignore

--- a/src/text.rs
+++ b/src/text.rs
@@ -11,8 +11,8 @@
 //! is a [`Line`].
 //!
 //! Keep it mind that a lot of widgets will use those types to advertise what kind of string is
-//! supported for their properties. Moreover, `ratatui` provides convenient `From` implementations so
-//! that you can start by using simple `String` or `&str` and then promote them to the previous
+//! supported for their properties. Moreover, `ratatui` provides convenient `From` implementations
+//! so that you can start by using simple `String` or `&str` and then promote them to the previous
 //! primitives when you need additional styling capabilities.
 //!
 //! For example, for the [`crate::widgets::Block`] widget, all the following calls are valid to set

--- a/src/widgets/chart.rs
+++ b/src/widgets/chart.rs
@@ -365,7 +365,8 @@ impl<'a> Chart<'a> {
             let first_label_width = first_x_label.content.width() as u16;
             let width_left_of_y_axis = match self.x_axis.labels_alignment {
                 Alignment::Left => {
-                    // The last character of the label should be below the Y-Axis when it exists, not on its left
+                    // The last character of the label should be below the Y-Axis when it exists,
+                    // not on its left
                     let y_axis_offset = u16::from(has_y_axis);
                     first_label_width.saturating_sub(y_axis_offset)
                 }
@@ -411,7 +412,8 @@ impl<'a> Chart<'a> {
         Self::render_label(buf, labels.first().unwrap(), label_area, label_alignment);
 
         for (i, label) in labels[1..labels.len() - 1].iter().enumerate() {
-            // We add 1 to x (and width-1 below) to leave at least one space before each intermediate labels
+            // We add 1 to x (and width-1 below) to leave at least one space before each
+            // intermediate labels
             let x = graph_area.left() + (i + 1) as u16 * width_between_ticks + 1;
             let label_area = Rect::new(x, y, width_between_ticks.saturating_sub(1), 1);
 

--- a/src/widgets/clear.rs
+++ b/src/widgets/clear.rs
@@ -2,8 +2,8 @@ use crate::{buffer::Buffer, layout::Rect, widgets::Widget};
 
 /// A widget to clear/reset a certain area to allow overdrawing (e.g. for popups).
 ///
-/// This widget **cannot be used to clear the terminal on the first render** as `ratatui` assumes the
-/// render area is empty. Use [`crate::Terminal::clear`] instead.
+/// This widget **cannot be used to clear the terminal on the first render** as `ratatui` assumes
+/// the render area is empty. Use [`crate::Terminal::clear`] instead.
 ///
 /// # Examples
 ///

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -219,8 +219,8 @@ pub trait StatefulWidget {
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State);
 }
 
-/// Macro that constructs and returns a [`Borders`] object from TOP, BOTTOM, LEFT, RIGHT, NONE, and ALL.
-/// Internally it creates an empty `Borders` object and then inserts each bit flag specified
+/// Macro that constructs and returns a [`Borders`] object from TOP, BOTTOM, LEFT, RIGHT, NONE, and
+/// ALL. Internally it creates an empty `Borders` object and then inserts each bit flag specified
 /// into it using `Borders::insert()`.
 ///
 /// ## Examples
@@ -240,8 +240,7 @@ pub trait StatefulWidget {
 /// let all = border!(ALL);
 /// //or with nothing to return a `Borders::NONE' bitflag.
 /// let none = border!(NONE);
-///
-///```
+/// ```
 #[cfg(feature = "macros")]
 #[macro_export]
 macro_rules! border {

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -208,8 +208,8 @@ mod test {
         Terminal,
     };
 
-    /// Tests the [`Paragraph`] widget against the expected [`Buffer`] by rendering it onto an equal area
-    /// and comparing the rendered and expected content.
+    /// Tests the [`Paragraph`] widget against the expected [`Buffer`] by rendering it onto an equal
+    /// area and comparing the rendered and expected content.
     /// This can be used for easy testing of varying configured paragraphs with the same expected
     /// buffer or any other test case really.
     fn test_case(paragraph: &Paragraph, expected: Buffer) {

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -19,9 +19,11 @@ pub trait LineComposer<'a> {
 /// A state machine that wraps lines on word boundaries.
 pub struct WordWrapper<'a, O, I>
 where
-    O: Iterator<Item = (I, Alignment)>, // Outer iterator providing the individual lines
-    I: Iterator<Item = StyledGrapheme<'a>>, // Inner iterator providing the styled symbols of a line
-                                        // Each line consists of an alignment and a series of symbols
+    // Outer iterator providing the individual lines
+    O: Iterator<Item = (I, Alignment)>,
+    // Inner iterator providing the styled symbols of a line Each line consists of an alignment and
+    // a series of symbols
+    I: Iterator<Item = StyledGrapheme<'a>>,
 {
     /// The given, unprocessed lines
     input_lines: O,
@@ -83,10 +85,13 @@ where
                     // Save the whole line's alignment
                     self.current_alignment = *line_alignment;
                     let mut wrapped_lines = vec![]; // Saves the wrapped lines
-                    let (mut current_line, mut current_line_width) = (vec![], 0); // Saves the unfinished wrapped line
-                    let (mut unfinished_word, mut word_width) = (vec![], 0); // Saves the partially processed word
+                                                    // Saves the unfinished wrapped line
+                    let (mut current_line, mut current_line_width) = (vec![], 0);
+                    // Saves the partially processed word
+                    let (mut unfinished_word, mut word_width) = (vec![], 0);
+                    // Saves the whitespaces of the partially unfinished word
                     let (mut unfinished_whitespaces, mut whitespace_width) =
-                        (VecDeque::<StyledGrapheme>::new(), 0); // Saves the whitespaces of the partially unfinished word
+                        (VecDeque::<StyledGrapheme>::new(), 0);
 
                     let mut has_seen_non_whitespace = false;
                     for StyledGrapheme { symbol, style } in line_symbols {
@@ -108,7 +113,8 @@ where
                             || word_width + whitespace_width + symbol_width > self.max_line_width && current_line.is_empty() && !self.trim
                         {
                             if !current_line.is_empty() || !self.trim {
-                                // Also append whitespaces if not trimming or current line is not empty
+                                // Also append whitespaces if not trimming or current line is not
+                                // empty
                                 current_line.extend(
                                     std::mem::take(&mut unfinished_whitespaces).into_iter(),
                                 );
@@ -124,7 +130,8 @@ where
                             word_width = 0;
                         }
 
-                        // Append the unfinished wrapped line to wrapped lines if it is as wide as max line width
+                        // Append the unfinished wrapped line to wrapped lines if it is as wide as
+                        // max line width
                         if current_line_width >= self.max_line_width
                             // or if it would be too long with the current partially processed word added
                             || current_line_width + whitespace_width + word_width >= self.max_line_width && symbol_width > 0
@@ -135,7 +142,8 @@ where
                             wrapped_lines.push(std::mem::take(&mut current_line));
                             current_line_width = 0;
 
-                            // Remove all whitespaces till end of just appended wrapped line + next whitespace
+                            // Remove all whitespaces till end of just appended wrapped line + next
+                            // whitespace
                             let mut first_whitespace = unfinished_whitespaces.pop_front();
                             while let Some(grapheme) = first_whitespace.as_ref() {
                                 let symbol_width = grapheme.symbol.width() as u16;
@@ -203,9 +211,11 @@ where
 /// A state machine that truncates overhanging lines.
 pub struct LineTruncator<'a, O, I>
 where
-    O: Iterator<Item = (I, Alignment)>, // Outer iterator providing the individual lines
-    I: Iterator<Item = StyledGrapheme<'a>>, // Inner iterator providing the styled symbols of a line
-                                        // Each line consists of an alignment and a series of symbols
+    // Outer iterator providing the individual lines
+    O: Iterator<Item = (I, Alignment)>,
+    // Inner iterator providing the styled symbols of a line Each line consists of an alignment and
+    // a series of symbols
+    I: Iterator<Item = StyledGrapheme<'a>>,
 {
     /// The given, unprocessed lines
     input_lines: O,
@@ -563,7 +573,8 @@ mod test {
         // to test double-width chars.
         // You are more than welcome to add word boundary detection based of alterations of
         // hiragana and katakana...
-        // This happens to also be a test case for mixed width because regular spaces are single width.
+        // This happens to also be a test case for mixed width because regular spaces are single
+        // width.
         let text = "コンピュ ータ上で文字を扱う場合、 典型的には文 字による 通信を行 う場合にその両端点では、";
         let (word_wrapper, word_wrapper_width, _) =
             run_composer(Composer::WordWrapper { trim: true }, text, width);

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -9,8 +9,8 @@ use ratatui::{
     Terminal,
 };
 
-/// Tests the [`Paragraph`] widget against the expected [`Buffer`] by rendering it onto an equal area
-/// and comparing the rendered and expected content.
+/// Tests the [`Paragraph`] widget against the expected [`Buffer`] by rendering it onto an equal
+/// area and comparing the rendered and expected content.
 fn test_case(paragraph: Paragraph, expected: Buffer) {
     let backend = TestBackend::new(expected.area.width, expected.area.height);
     let mut terminal = Terminal::new(backend).unwrap();


### PR DESCRIPTION
This is an opinionated default that helps avoid horizontal scrolling.
100 is the most common width on github rust projects and works well for
displaying code on a 16in macbook pro.
