### PR TITLE
chore(ci): integrate cargo-deny for linting dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
           commits: "HEAD"
       - name: "Check typos"
         uses: crate-ci/typos@master
+      - name: "Lint dependencies"
+        uses: EmbarkStudios/cargo-deny-action@v1
 
   coverage:
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,20 @@
+# configuration for https://github.com/EmbarkStudios/cargo-deny
+
+[licenses]
+default = "deny"
+unlicensed = "deny"
+copyleft = "deny"
+confidence-threshold = 0.8
+allow = ["Apache-2.0", "BSD-3-Clause", "MIT", "Unicode-DFS-2016", "WTFPL"]
+
+[advisories]
+unmaintained = "deny"
+yanked = "deny"
+
+[bans]
+multiple-versions = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
See https://github.com/EmbarkStudios/cargo-deny
