### PR TITLE
feat(terminal): expose 'swap_buffers' method

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -292,9 +292,7 @@ where
             }
         }
 
-        // Swap buffers
-        self.buffers[1 - self.current].reset();
-        self.current = 1 - self.current;
+        self.swap_buffers();
 
         // Flush
         self.backend.flush()?;
@@ -346,6 +344,12 @@ where
         // Reset the back buffer to make sure the next update will redraw everything.
         self.buffers[1 - self.current].reset();
         Ok(())
+    }
+
+    /// Clears the inactive buffer and swaps it with the current buffer
+    pub fn swap_buffers(&mut self) {
+        self.buffers[1 - self.current].reset();
+        self.current = 1 - self.current;
     }
 
     /// Queries the real size of the backend.

--- a/tests/terminal.rs
+++ b/tests/terminal.rs
@@ -16,6 +16,18 @@ fn terminal_buffer_size_should_be_limited() {
 }
 
 #[test]
+fn swap_buffer_clears_prev_buffer() {
+    let backend = TestBackend::new(100, 50);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .current_buffer_mut()
+        .set_string(0, 0, "Hello", ratatui::style::Style::reset());
+    assert_eq!(terminal.current_buffer_mut().content()[0].symbol, "H");
+    terminal.swap_buffers();
+    assert_eq!(terminal.current_buffer_mut().content()[0].symbol, " ");
+}
+
+#[test]
 fn terminal_draw_returns_the_completed_frame() -> Result<(), Box<dyn Error>> {
     let backend = TestBackend::new(10, 10);
     let mut terminal = Terminal::new(backend)?;


### PR DESCRIPTION
I needed raw access to clearing/swapping the buffers, I think it doesn't hurt to expose this functionality.