### PR TITLE
feat(buffer): use 'smartstring' for the buffer cell for better cache coherence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [dependencies]
 bitflags = "2.3"
+smartstring = "1.0"
 cassowary = "0.3"
 crossterm = { version = "0.26", optional = true }
 indoc = "2.0"

--- a/src/backend/termwiz.rs
+++ b/src/backend/termwiz.rs
@@ -129,7 +129,7 @@ impl Backend for TermwizBackend {
                     },
                 )));
 
-            self.buffered_terminal.add_change(&cell.symbol);
+            self.buffered_terminal.add_change(&*cell.symbol);
         }
         Ok(())
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -4,6 +4,7 @@ use crate::{
     style::{Color, Modifier, Style},
     text::{Line, Span, Spans},
 };
+use smartstring::alias::CompactString;
 use std::{
     cmp::min,
     fmt::{Debug, Formatter, Result},
@@ -14,7 +15,7 @@ use unicode_width::UnicodeWidthStr;
 /// A buffer cell
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Cell {
-    pub symbol: String,
+    pub symbol: CompactString,
     pub fg: Color,
     pub bg: Color,
     pub modifier: Modifier,
@@ -101,7 +102,7 @@ impl Default for Cell {
 /// assert_eq!(buf.get(0, 2).symbol, "x");
 /// buf.set_string(3, 0, "string", Style::default().fg(Color::Red).bg(Color::White));
 /// assert_eq!(buf.get(5, 0), &Cell{
-///     symbol: String::from("r"),
+///     symbol: "r".into(),
 ///     fg: Color::Red,
 ///     bg: Color::White,
 ///     modifier: Modifier::empty()


### PR DESCRIPTION
This should optimize the buffer a little bit.
Currently all symbol lookups when iterating through the buffer are to the heap , it's better to keep the data close to each other for cache coherence. I have not benched this though, this just caught my eye while going through the source.
With this change, there will likely only be one heap lookup, when iterating through the buffer, only extremely exotic symbols will be on the heap I guess.