### PR TITLE
chore(github): fix the syntax in CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+
+# It uses the same pattern rule for gitignore file
+# https://git-scm.com/docs/gitignore#_pattern_format
+
+# Maintainers
+* @orhun
+* @mindoodoo
+* @sayanarijit
+* @sophacles
+* @joshka

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,0 @@
-@orhun
-@mindoodoo
-@sayanarijit
-@sophacles
-@joshka


### PR DESCRIPTION
- Fixed the syntax (mind the `*` for giving access to the files)
- Moved CODEOWNERS to .github directory (since it is more relevant there)
