### PR TITLE
fix(examples): Correct progress label in gague example

### DIFF
--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -153,7 +153,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
         .use_unicode(true);
     f.render_widget(gauge, chunks[2]);
 
-    let label = format!("{}/100", app.progress2);
+    let label = format!("{}/100", app.progress4);
     let gauge = Gauge::default()
         .block(Block::default().title("Gauge4"))
         .gauge_style(


### PR DESCRIPTION
:wave: Hey folks,

Was trialing out the library last night when I noticed that gauge4's label vs percentage complete was a bit off.  Read through the example a bit more closely to understand what the issue was.  Just thought I'd throw this up for posterity.

Cheers,
Chris