### PR TITLE
fix: revert removal of WTFPL from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ allow = [
     "ISC",
     "MIT",
     "Unicode-DFS-2016",
+    "WTFPL",
 ]
 
 [advisories]


### PR DESCRIPTION
This is actually used for terminfo (transitively from termwiz

```
error[rejected]: failed to satisfy license requirements
  ┌─ terminfo 0.7.5 (registry+https://github.com/rust-lang/crates.io-index):4:12
  │
4 │ license = "WTFPL"
  │            ^^^^^
  │            │
  │            license expression retrieved via Cargo.toml `license`
  │            rejected: not explicitly allowed
  │
  = terminfo v0.7.5
    └── termwiz v0.20.0
        └── ratatui v0.21.0

advisories ok, bans ok, licenses FAILED, sources ok
```