### PR TITLE
docs: fix scrollbar ascii illustrations and calendar doc paths

### DIFF
--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -1,6 +1,7 @@
 #[path = "../title.rs"]
 pub mod title;
 
+use self::title::{Position, Title};
 use crate::{
     buffer::Buffer,
     layout::{Alignment, Rect},
@@ -8,8 +9,6 @@ use crate::{
     symbols::line,
     widgets::{Borders, Widget},
 };
-
-use self::title::{Position, Title};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BorderType {
@@ -113,7 +112,6 @@ impl Padding {
 ///     .border_type(BorderType::Rounded)
 ///     .style(Style::default().bg(Color::Black));
 /// ```
-///
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Block<'a> {
     /// List of titles
@@ -129,7 +127,8 @@ pub struct Block<'a> {
     borders: Borders,
     /// Border style
     border_style: Style,
-    /// Type of the border. The default is plain lines but one can choose to have rounded or doubled lines instead.
+    /// Type of the border. The default is plain lines but one can choose to have rounded or
+    /// doubled lines instead.
     border_type: BorderType,
 
     /// Widget style
@@ -166,18 +165,24 @@ impl<'a> Block<'a> {
     ///        Title::from("Center")
     ///            .alignment(Alignment::Center),
     ///    );
-    ///```
+    /// ```
     /// Adds a title to the block.
     ///
-    /// The `title` function allows you to add a title to the block. You can call this function multiple times to add multiple titles.
+    /// The `title` function allows you to add a title to the block. You can call this function
+    /// multiple times to add multiple titles.
     ///
-    /// Each title will be rendered with a single space separating titles that are in the same position or alignment. When both centered and non-centered titles are rendered, the centered space is calculated based on the full width of the block, rather than the leftover width.
+    /// Each title will be rendered with a single space separating titles that are in the same
+    /// position or alignment. When both centered and non-centered titles are rendered, the centered
+    /// space is calculated based on the full width of the block, rather than the leftover width.
     ///
-    /// You can provide various types as the title, including strings, string slices, borrowed strings (`Cow<str>`), spans, or vectors of spans (`Vec<Span>`).
+    /// You can provide various types as the title, including strings, string slices, borrowed
+    /// strings (`Cow<str>`), spans, or vectors of spans (`Vec<Span>`).
     ///
-    /// By default, the titles will avoid being rendered in the corners of the block but will align against the left or right edge of the block if there is no border on that edge.
+    /// By default, the titles will avoid being rendered in the corners of the block but will align
+    /// against the left or right edge of the block if there is no border on that edge.
     ///
-    /// Note: If the block is too small and multiple titles overlap, the border might get cut off at a corner.
+    /// Note: If the block is too small and multiple titles overlap, the border might get cut off at
+    /// a corner.
     pub fn title<T>(mut self, title: T) -> Block<'a>
     where
         T: Into<Title<'a>>,

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -71,7 +71,7 @@ impl<'a, S: DateStyler> Monthly<'a, S> {
         self
     }
 
-    /// Render the calendar within a [Block](ratatui::widgets::Block)
+    /// Render the calendar within a [Block](crate::widgets::Block)
     pub fn block(mut self, b: Block<'a>) -> Self {
         self.block = Some(b);
         self
@@ -164,7 +164,7 @@ impl<'a, S: DateStyler> Widget for Monthly<'a, S> {
     }
 }
 
-/// Provides a method for styling a given date. [Month] is generic on this trait, so any type
+/// Provides a method for styling a given date. [Monthly] is generic on this trait, so any type
 /// that implements this trait can be used.
 pub trait DateStyler {
     /// Given a date, return a style for that date

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -7,12 +7,14 @@ use crate::{
 };
 
 /// Scrollbar Set
+/// ```text
 /// <--▮------->
 /// ^  ^   ^   ^
 /// │  │   │   └ end
 /// │  │   └──── track
 /// │  └──────── thumb
 /// └─────────── begin
+/// ```
 #[derive(Debug, Clone)]
 pub struct Set {
     pub track: &'static str,
@@ -67,12 +69,14 @@ pub enum ScrollDirection {
 /// - the `content_length` is 4
 /// - the `viewport_content_length` is 2
 ///
+/// ```text
 /// ┌───────────────┐
 /// │1. this is a   █
 /// │   single item █
 /// │2. this is a   ║
 /// │   second item ║
 /// └───────────────┘
+/// ```
 ///
 /// If you don't have multi-line content, you can leave the `viewport_content_length` set to the
 /// default of 0 and it'll use the track size as a `viewport_content_length`.
@@ -156,12 +160,14 @@ pub enum ScrollbarOrientation {
 /// This widget can be used to display a scrollbar in a terminal user interface.
 /// The following components of the scrollbar are customizable in symbol and style.
 ///
+/// ```text
 /// <--▮------->
 /// ^  ^   ^   ^
 /// │  │   │   └ end
 /// │  │   └──── track
 /// │  └──────── thumb
 /// └─────────── begin
+/// ```
 #[derive(Debug, Clone)]
 pub struct Scrollbar<'a> {
     orientation: ScrollbarOrientation,
@@ -264,12 +270,14 @@ impl<'a> Scrollbar<'a> {
 
     /// Sets the symbols used for the various parts of the scrollbar from a [`Set`].
     ///
+    /// ```text
     /// <--▮------->
     /// ^  ^   ^   ^
     /// │  │   │   └ end
     /// │  │   └──── track
     /// │  └──────── thumb
     /// └─────────── begin
+    /// ```
     ///
     /// Only sets begin_symbol and end_symbol if they already contain a value.
     /// If begin_symbol and/or end_symbol were set to `None` explicitly, this function will respect
@@ -287,12 +295,14 @@ impl<'a> Scrollbar<'a> {
     }
 
     /// Sets the style used for the various parts of the scrollbar from a [`Style`].
+    /// ```text
     /// <--▮------->
     /// ^  ^   ^   ^
     /// │  │   │   └ end
     /// │  │   └──── track
     /// │  └──────── thumb
     /// └─────────── begin
+    /// ```
     pub fn style(mut self, style: Style) -> Self {
         self.track_style = style;
         self.thumb_style = style;


### PR DESCRIPTION
This PR fixes scrollbar's documentation, which tried to showcase its elements. This requires for the text to be rendered exactly how it was written, which isn't the case for the cargo and other tools. Thus, it requires to be wrapped inside text blocks, which preserves text as is.
Secondly, there were problems with doc paths in calendar's documentation. 
Finally, recently merged changes in `block.rs` were not formatted properly