### PR TITLE
style(widget): use inline format arguments

### DIFF
--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -90,10 +90,10 @@ impl Debug for Borders {
                 continue;
             }
             if first {
-                write!(f, "{}", name)?;
+                write!(f, "{name}")?;
                 first = false;
             } else {
-                write!(f, " | {}", name)?;
+                write!(f, " | {name}")?;
             }
         }
         Ok(())


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

This is a continuation of #190, that I noticed while working on the `const` branch.