### PR TITLE
fix(clippy): fix unused_mut lint for layout

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -224,7 +224,7 @@ fn split(area: Rect, layout: &Layout) -> Rc<[Rect]> {
         .map(|_| Rect::default())
         .collect::<Rc<[Rect]>>();
 
-    let mut results = Rc::get_mut(&mut res).expect("newly created Rc should have no shared refs");
+    let results = Rc::get_mut(&mut res).expect("newly created Rc should have no shared refs");
 
     let dest_area = area.inner(&layout.margin);
     for (i, e) in elements.iter().enumerate() {


### PR DESCRIPTION
This lint is slightly more agressive in +nightly than it is in stable.

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
