### PR TITLE
chore(tests): setup coverage monitoring in bacon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,14 @@ If an area that you're making a change in is not tested, write tests to characte
 behavior before changing it. This helps ensure that we don't introduce bugs to existing software
 using Ratatui (and helps make it easy to migrate apps still using `tui-rs`).
 
+For coverage, we have two [bacon](https://dystroy.org/bacon/) jobs (one for all tests, and one for
+unit tests, keyboard shortcuts `v` and `u` respectively) that run
+[cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) to report the coverage. Several plugins
+exist to show coverage directly in your editor. E.g.:
+
+- <https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters>
+- <https://github.com/alepez/vim-llvmcov>
+
 ### Use of unsafe for optimization purposes
 
 We don't currently use any unsafe code in Ratatui, and would like to keep it that way. However there

--- a/bacon.toml
+++ b/bacon.toml
@@ -15,6 +15,18 @@ need_stdout = false
 command = ["cargo", "check", "--all-targets", "--all-features", "--color", "always"]
 need_stdout = false
 
+[jobs.check-crossterm]
+command = ["cargo", "check", "--color", "always", "--all-targets", "--no-default-features", "--features", "crossterm"]
+need_stdout = false
+
+[jobs.check-termion]
+command = ["cargo", "check", "--color", "always", "--all-targets", "--no-default-features", "--features", "termion"]
+need_stdout = false
+
+[jobs.check-termwiz]
+command = ["cargo", "check", "--color", "always", "--all-targets", "--no-default-features", "--features", "termwiz"]
+need_stdout = false
+
 [jobs.clippy]
 command = [
     "cargo", "clippy",
@@ -58,27 +70,22 @@ env.RUSTDOCFLAGS = "--cfg docsrs"
 need_stdout = false
 on_success = "job:doc" # so that we don't open the browser at each change
 
-# You can run your application and have the result displayed in bacon,
-# *if* it makes sense for this crate. You can run an example the same
-# way. Don't forget the `--color always` part or the errors won't be
-# properly parsed.
-[jobs.run]
+[jobs.coverage]
 command = [
-    "cargo", "run",
+    "cargo", "llvm-cov",
+    "--lcov", "--output-path", "target/lcov.info",
+    "--all-features", 
     "--color", "always",
-    # put launch parameters for your program behind a `--` separator
 ]
-need_stdout = true
-allow_warnings = true
 
-[jobs.check-crossterm]
-command = ["cargo", "check", "--color", "always", "--all-targets", "--no-default-features", "--features", "crossterm"]
-
-[jobs.check-termion]
-command = ["cargo", "check", "--color", "always", "--all-targets", "--no-default-features", "--features", "termion"]
-
-[jobs.check-termwiz]
-command = ["cargo", "check", "--color", "always", "--all-targets", "--no-default-features", "--features", "termwiz"]
+[jobs.coverage-unit-tests-only]
+command = [
+    "cargo", "llvm-cov",
+    "--lcov", "--output-path", "target/lcov.info",
+    "--lib",
+    "--all-features",
+    "--color", "always",
+]
 
 # You may define here keybindings that would be specific to
 # a project, for example a shortcut to launch a specific job.
@@ -89,3 +96,5 @@ command = ["cargo", "check", "--color", "always", "--all-targets", "--no-default
 ctrl-c = "job:check-crossterm"
 ctrl-t = "job:check-termion"
 ctrl-w = "job:check-termwiz"
+v = "job:coverage"
+u = "job:coverage-unit-tests-only"


### PR DESCRIPTION
- Add two jobs to bacon.toml (one for unit tests, one for all tests)
- Remove "run" job as it doesn't work well with bacon due to no stdin
- Document coverage tooling in CONTRIBUTING.md

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
