### PR TITLE
rust-tui-template become a revival project

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ be installed with `cargo install cargo-make`).
   `tui::text::Text`
 * [color-to-tui](https://github.com/uttarayan21/color-to-tui) — Parse hex colors to
   `tui::style::Color`
-* [rust-tui-template](https://github.com/orhun/rust-tui-template) — A template for bootstrapping a
+* [rust-tui-template](https://github.com/rust-tui-revival/rust-tui-template) — A template for bootstrapping a
   Rust TUI application with Tui-rs & crossterm
 * [simple-tui-rs](https://github.com/pmsanford/simple-tui-rs) — A simple example tui-rs app
 * [tui-builder](https://github.com/jkelleyrtp/tui-builder) — Batteries-included MVC framework for


### PR DESCRIPTION
Changed the URL https://github.com/orhun/rust-tui-template into https://github.com/rust-tui-revival/rust-tui-template