### PR TITLE
fix(prelude): remove widgets module from prelude

### DIFF
--- a/examples/barchart.rs
+++ b/examples/barchart.rs
@@ -9,7 +9,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 struct Company<'a> {
     revenue: [u64; 4],

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -5,7 +5,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // setup terminal
@@ -55,7 +55,7 @@ fn ui<B: Backend>(f: &mut Frame<B>) {
     // Surrounding block
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(BlockTitle::from("Main block with round corners").alignment(Alignment::Center))
+        .title(block::Title::from("Main block with round corners").alignment(Alignment::Center))
         .border_type(BorderType::Rounded);
     f.render_widget(block, size);
 
@@ -79,7 +79,7 @@ fn ui<B: Backend>(f: &mut Frame<B>) {
 
     // Top right inner block with styled title aligned to the right
     let block = Block::default().title(
-        BlockTitle::from("Styled title".white().on_red().bold()).alignment(Alignment::Right),
+        block::Title::from("Styled title".white().on_red().bold()).alignment(Alignment::Right),
     );
     f.render_widget(block, top_chunks[1]);
 

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -5,7 +5,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::calendar::*};
 use time::{Date, Month, OffsetDateTime};
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -9,7 +9,10 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{
+    prelude::*,
+    widgets::{canvas::*, *},
+};
 
 struct App {
     x: f64,

--- a/examples/chart.rs
+++ b/examples/chart.rs
@@ -9,7 +9,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 const DATA: [(f64, f64); 5] = [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0)];
 const DATA2: [(f64, f64); 7] = [

--- a/examples/custom_widget.rs
+++ b/examples/custom_widget.rs
@@ -5,7 +5,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 #[derive(Default)]
 struct Label<'a> {

--- a/examples/demo/app.rs
+++ b/examples/demo/app.rs
@@ -2,7 +2,7 @@ use rand::{
     distributions::{Distribution, Uniform},
     rngs::ThreadRng,
 };
-use ratatui::prelude::*;
+use ratatui::widgets::*;
 
 const TASKS: [&str; 24] = [
     "Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "Item8", "Item9", "Item10",

--- a/examples/demo/ui.rs
+++ b/examples/demo/ui.rs
@@ -1,4 +1,7 @@
-use ratatui::prelude::*;
+use ratatui::{
+    prelude::*,
+    widgets::{canvas::*, *},
+};
 
 use crate::app::App;
 
@@ -10,7 +13,7 @@ pub fn draw<B: Backend>(f: &mut Frame<B>, app: &mut App) {
         .tabs
         .titles
         .iter()
-        .map(|t| Line::from(Span::styled(*t, Style::default().fg(Color::Green))))
+        .map(|t| text::Line::from(Span::styled(*t, Style::default().fg(Color::Green))))
         .collect();
     let tabs = Tabs::new(titles)
         .block(Block::default().borders(Borders::ALL).title(app.title))
@@ -127,7 +130,7 @@ where
                 .tasks
                 .items
                 .iter()
-                .map(|i| ListItem::new(vec![Line::from(Span::raw(*i))]))
+                .map(|i| ListItem::new(vec![text::Line::from(Span::raw(*i))]))
                 .collect();
             let tasks = List::new(tasks)
                 .block(Block::default().borders(Borders::ALL).title("List"))
@@ -151,7 +154,7 @@ where
                         "WARNING" => warning_style,
                         _ => info_style,
                     };
-                    let content = vec![Line::from(vec![
+                    let content = vec![text::Line::from(vec![
                         Span::styled(format!("{level:<9}"), s),
                         Span::raw(evt),
                     ])];
@@ -251,9 +254,9 @@ where
     B: Backend,
 {
     let text = vec![
-        Line::from("This is a paragraph with several lines. You can change style your text the way you want"),
-        Line::from(""),
-        Line::from(vec![
+        text::Line::from("This is a paragraph with several lines. You can change style your text the way you want"),
+        text::Line::from(""),
+        text::Line::from(vec![
             Span::from("For example: "),
             Span::styled("under", Style::default().fg(Color::Red)),
             Span::raw(" "),
@@ -262,7 +265,7 @@ where
             Span::styled("rainbow", Style::default().fg(Color::Blue)),
             Span::raw("."),
         ]),
-        Line::from(vec![
+        text::Line::from(vec![
             Span::raw("Oh and if you didn't "),
             Span::styled("notice", Style::default().add_modifier(Modifier::ITALIC)),
             Span::raw(" you can "),
@@ -273,7 +276,7 @@ where
             Span::styled("text", Style::default().add_modifier(Modifier::UNDERLINED)),
             Span::raw(".")
         ]),
-        Line::from(
+        text::Line::from(
             "One more thing is that it should display unicode characters: 10€"
         ),
     ];
@@ -344,7 +347,7 @@ where
             });
             for (i, s1) in app.servers.iter().enumerate() {
                 for s2 in &app.servers[i + 1..] {
-                    ctx.draw(&CanvasLine {
+                    ctx.draw(&canvas::Line {
                         x1: s1.coords.1,
                         y1: s1.coords.0,
                         y2: s2.coords.0,

--- a/examples/gauge.rs
+++ b/examples/gauge.rs
@@ -9,7 +9,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 struct App {
     progress1: u16,

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -9,7 +9,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 /// This is a bare minimum example. There are many approaches to running an application loop, so
 /// this is not meant to be prescriptive. It is only meant to demonstrate the basic setup and

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use rand::distributions::{Distribution, Uniform};
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 const NUM_DOWNLOADS: usize = 10;
 
@@ -219,7 +219,7 @@ fn run_app<B: Backend>(
 fn ui<B: Backend>(f: &mut Frame<B>, downloads: &Downloads) {
     let size = f.size();
 
-    let block = Block::default().title(BlockTitle::from("Progress").alignment(Alignment::Center));
+    let block = Block::default().title(block::Title::from("Progress").alignment(Alignment::Center));
     f.render_widget(block, size);
 
     let chunks = Layout::default()

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -5,7 +5,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // setup terminal

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -9,7 +9,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 struct StatefulList<T> {
     state: ListState,

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -14,16 +14,13 @@
 //! That's why this example is set up to show both situations, with and without
 //! the chained panic hook, to see the difference.
 
-#![deny(clippy::all)]
-#![warn(clippy::pedantic, clippy::nursery)]
-
 use std::{error::Error, io};
 
 use crossterm::{
     event::{self, Event, KeyCode},
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
 

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -9,7 +9,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 struct App {
     scroll: u16,

--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -5,7 +5,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 struct App {
     show_popup: bool,

--- a/examples/scrollbar.rs
+++ b/examples/scrollbar.rs
@@ -9,7 +9,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::{prelude::*, widgets::scrollbar};
+use ratatui::{prelude::*, widgets::*};
 
 #[derive(Default)]
 struct App {

--- a/examples/sparkline.rs
+++ b/examples/sparkline.rs
@@ -13,7 +13,7 @@ use rand::{
     distributions::{Distribution, Uniform},
     rngs::ThreadRng,
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 #[derive(Clone)]
 pub struct RandomSignal {

--- a/examples/table.rs
+++ b/examples/table.rs
@@ -5,7 +5,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 struct App<'a> {
     state: TableState,

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -5,7 +5,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 struct App<'a> {
     pub titles: Vec<&'a str>,

--- a/examples/user_input.rs
+++ b/examples/user_input.rs
@@ -19,7 +19,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
+use ratatui::{prelude::*, widgets::*};
 
 enum InputMode {
     Normal,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,35 +188,4 @@ pub mod widgets;
 
 pub use self::terminal::{Frame, Terminal, TerminalOptions, Viewport};
 
-/// A prelude for conveniently writing applications using this library.
-///
-/// ```rust,no_run
-/// use ratatui::prelude::*;
-/// ```
-pub mod prelude {
-    #[cfg(feature = "crossterm")]
-    pub use crate::backend::CrosstermBackend;
-    #[cfg(feature = "termion")]
-    pub use crate::backend::TermionBackend;
-    #[cfg(feature = "termwiz")]
-    pub use crate::backend::TermwizBackend;
-    #[cfg(feature = "widget-calendar")]
-    pub use crate::widgets::calendar::{CalendarEventStore, DateStyler, Monthly};
-    pub use crate::{
-        backend::Backend,
-        buffer::Buffer,
-        layout::{Alignment, Constraint, Corner, Direction, Layout, Margin, Rect},
-        style::{Color, Modifier, Style, Styled, Stylize},
-        symbols::{self, Marker},
-        terminal::{Frame, Terminal, TerminalOptions, Viewport},
-        text::{Line, Masked, Span, Text},
-        widgets::{
-            block::{Block, Position as BlockTitlePosition, Title as BlockTitle},
-            canvas::{Canvas, Circle, Line as CanvasLine, Map, MapResolution, Rectangle},
-            Axis, Bar, BarChart, BarGroup, BorderType, Borders, Cell, Chart, Clear, Dataset, Gauge,
-            GraphType, LineGauge, List, ListItem, ListState, Padding, Paragraph, RenderDirection,
-            Row, ScrollDirection, Scrollbar, ScrollbarOrientation, ScrollbarState, Sparkline,
-            StatefulWidget, Table, TableState, Tabs, Widget, Wrap,
-        },
-    };
-}
+pub mod prelude;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,35 @@
+//! A prelude for conveniently writing applications using this library.
+//!
+//! ```rust,no_run
+//! use ratatui::prelude::*;
+//! ```
+//!
+//! Aside from the main types that are used in the library, this prelude also re-exports several
+//! modules to make it easy to qualify types that would otherwise collide. E.g.:
+//!
+//! ```rust
+//! use ratatui::{prelude::*, widgets::*};
+//! use ratatui::widgets::{Block, Borders};
+//!
+//! #[derive(Debug, Default, PartialEq, Eq)]
+//! struct Line;
+//!
+//! assert_eq!(Line::default(), Line);
+//! assert_eq!(text::Line::default(), ratatui::text::Line::from(vec![]));
+//! ```
+
+#[cfg(feature = "crossterm")]
+pub use crate::backend::CrosstermBackend;
+#[cfg(feature = "termion")]
+pub use crate::backend::TermionBackend;
+#[cfg(feature = "termwiz")]
+pub use crate::backend::TermwizBackend;
+pub use crate::{
+    backend::{self, Backend},
+    buffer::{self, Buffer},
+    layout::{self, Alignment, Constraint, Corner, Direction, Layout, Margin, Rect},
+    style::{self, Color, Modifier, Style, Styled, Stylize},
+    symbols::{self, Marker},
+    terminal::{self, Frame, Terminal, TerminalOptions, Viewport},
+    text::{self, Line, Masked, Span, Text},
+};

--- a/src/style.rs
+++ b/src/style.rs
@@ -133,7 +133,7 @@ pub enum Color {
     White,
     /// An RGB color
     Rgb(u8, u8, u8),
-    /// An 8-bit 256 color. See https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
+    /// An 8-bit 256 color. See <https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit>
     Indexed(u8),
 }
 

--- a/src/widgets/barchart/bar.rs
+++ b/src/widgets/barchart/bar.rs
@@ -7,7 +7,7 @@ use crate::{buffer::Buffer, style::Style, text::Line};
 /// red background and a white value foreground
 ///
 /// ```
-/// # use ratatui::prelude::*;
+/// # use ratatui::{prelude::*, widgets::*};
 /// Bar::default()
 ///     .label("Bar 1".into())
 ///     .value(10)

--- a/src/widgets/barchart/bar_group.rs
+++ b/src/widgets/barchart/bar_group.rs
@@ -5,7 +5,7 @@ use crate::text::Line;
 ///
 /// # Examples
 /// ```
-/// # use ratatui::prelude::*;
+/// # use ratatui::{prelude::*, widgets::*};
 /// BarGroup::default()
 ///     .label("Group 1".into())
 ///     .bars(&[Bar::default().value(200), Bar::default().value(150)]);

--- a/src/widgets/barchart/mod.rs
+++ b/src/widgets/barchart/mod.rs
@@ -6,14 +6,16 @@ mod bar_group;
 pub use bar::Bar;
 pub use bar_group::BarGroup;
 
+use super::{Block, Widget};
+
 /// Display multiple bars in a single widgets
 ///
 /// # Examples
 /// The following example creates a BarChart with two groups of bars.
 /// The first group is added by an array slice (&[(&str, u64)]).
-/// The second group is added by a slice of Groups (&[Group]).
+/// The second group is added by a slice of Groups (&[BarGroup]).
 /// ```
-/// # use ratatui::prelude::*;
+/// # use ratatui::{prelude::*, widgets::*};
 /// BarChart::default()
 ///     .block(Block::default().title("BarChart").borders(Borders::ALL))
 ///     .bar_width(3)
@@ -78,7 +80,7 @@ impl<'a> BarChart<'a> {
     /// The first group is added by an array slice (&[(&str, u64)]).
     /// The second group is added by a BarGroup instance.
     /// ```
-    /// # use ratatui::prelude::*;
+    /// # use ratatui::{prelude::*, widgets::*};
     ///
     /// BarChart::default()
     ///        .data(&[("B0", 0), ("B1", 2), ("B2", 4), ("B3", 3)])
@@ -338,7 +340,10 @@ mod tests {
     use itertools::iproduct;
 
     use super::*;
-    use crate::assert_buffer_eq;
+    use crate::{
+        assert_buffer_eq,
+        widgets::{BorderType, Borders},
+    };
 
     #[test]
     fn default() {


### PR DESCRIPTION
This helps to keep the prelude small and less likely to conflict with
other crates.

- remove widgets module from prelude as the entire module can be just as
  easily imported with `use ratatui::widgets::*;`
- move prelude module into its own file
- update examples to import widgets module instead of just prelude
- added several modules to prelude to make it possible to qualify
  imports that collide with other types that have similar names

## Note

In the [discussion of this on discord](https://discord.com/channels/1070692720437383208/1072879985762762812/1129381084010909756), just the canvas was suggested to be removed, however given that it's fairly easy to import widgets::*, it makes sense to drop the entire module from the prelude.