### PR TITLE
fix(title): remove default alignment and position

### DIFF
--- a/src/title.rs
+++ b/src/title.rs
@@ -50,8 +50,8 @@ impl<'a> Default for Title<'a> {
     fn default() -> Self {
         Self {
             content: Line::from(""),
-            alignment: Some(Alignment::Left),
-            position: Some(Position::Top),
+            alignment: None,
+            position: None,
         }
     }
 }

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -515,6 +515,7 @@ impl<'a> Styled for Block<'a> {
 mod tests {
     use super::*;
     use crate::{
+        assert_buffer_eq,
         layout::Rect,
         style::{Color, Modifier, Stylize},
     };
@@ -889,13 +890,36 @@ mod tests {
     }
 
     #[test]
-    fn title_is_aligned_on_center() {
-        assert_eq!(
+    fn title_alignment() {
+        let tests = vec![
+            (Alignment::Left, "test    "),
+            (Alignment::Center, "  test  "),
+            (Alignment::Right, "    test"),
+        ];
+        for (alignment, expected) in tests {
+            let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 1));
             Block::default()
                 .title("test")
-                .title_alignment(Alignment::Center)
-                .titles_alignment,
-            Alignment::Center
-        );
+                .title_alignment(alignment)
+                .render(buffer.area, &mut buffer);
+            assert_buffer_eq!(buffer, Buffer::with_lines(vec![expected]));
+        }
+    }
+
+    #[test]
+    fn title_alignment_overrides_block_title_alignment() {
+        let tests = vec![
+            (Alignment::Right, Alignment::Left, "test    "),
+            (Alignment::Left, Alignment::Center, "  test  "),
+            (Alignment::Center, Alignment::Right, "    test"),
+        ];
+        for (block_title_alignment, alignment, expected) in tests {
+            let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 1));
+            Block::default()
+                .title(Title::from("test").alignment(alignment))
+                .title_alignment(block_title_alignment)
+                .render(buffer.area, &mut buffer);
+            assert_buffer_eq!(buffer, Buffer::with_lines(vec![expected]));
+        }
     }
 }

--- a/src/widgets/block.rs
+++ b/src/widgets/block.rs
@@ -887,4 +887,15 @@ mod tests {
                 .remove_modifier(Modifier::DIM)
         )
     }
+
+    #[test]
+    fn title_is_aligned_on_center() {
+        assert_eq!(
+            Block::default()
+                .title("test")
+                .title_alignment(Alignment::Center)
+                .titles_alignment,
+            Alignment::Center
+        );
+    }
 }

--- a/tests/widgets_block.rs
+++ b/tests/widgets_block.rs
@@ -295,8 +295,13 @@ fn widgets_block_title_alignment() {
         let backend = TestBackend::new(15, 2);
         let mut terminal = Terminal::new(backend).unwrap();
 
-        let block = Block::default()
+        let block1 = Block::default()
             .title(Title::from(Span::styled("Title", Style::default())).alignment(alignment))
+            .borders(borders);
+
+        let block2 = Block::default()
+            .title("Title")
+            .title_alignment(alignment)
             .borders(borders);
 
         let area = Rect {
@@ -306,13 +311,15 @@ fn widgets_block_title_alignment() {
             height: 2,
         };
 
-        terminal
-            .draw(|f| {
-                f.render_widget(block, area);
-            })
-            .unwrap();
+        for block in [block1, block2] {
+            terminal
+                .draw(|f| {
+                    f.render_widget(block, area);
+                })
+                .unwrap();
 
-        terminal.backend().assert_buffer(&expected);
+            terminal.backend().assert_buffer(&expected);
+        }
     };
 
     // title top-left with all borders


### PR DESCRIPTION
fixes #322

we already have defaults in:

https://github.com/tui-rs-revival/ratatui/blob/446efae185a5bb02a9ab6481542d1dc3024b66a9/src/widgets/block.rs#L151-L152