### PR TITLE
docs: improve scrollbar doc comment

### DIFF
--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -155,9 +155,8 @@ pub enum ScrollbarOrientation {
     HorizontalTop,
 }
 
-/// Scrollbar widget for tui-rs library.
+/// A widget to display a scrollbar
 ///
-/// This widget can be used to display a scrollbar in a terminal user interface.
 /// The following components of the scrollbar are customizable in symbol and style.
 ///
 /// ```text


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

I find the title is not really needed for the doc comment.

Alternative:

Rename `tui-rs` to `ratatui` in the title, but I find that this is not needed.
