### PR TITLE
build: forbid unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 //! [ratatui](https://github.com/tui-rs-revival/ratatui) is a library used to build rich
 //! terminal users interfaces and dashboards.
 //!


### PR DESCRIPTION
This indicates good (high level) code and is used by tools like cargo-geiger.

Reading #66 it also sounds like a good idea to have this unless someone has a really good explanation to remove this.

Also see https://github.com/tui-rs-revival/ratatui/pull/157#discussion_r1200281899

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->
